### PR TITLE
fix: Binary HTTP format parses quoted tokens according to RFC 7230 section 3.2.6

### DIFF
--- a/lib/cloud_events/http_binding.rb
+++ b/lib/cloud_events/http_binding.rb
@@ -254,6 +254,7 @@ module CloudEvents
     # @return [String] Resulting decoded string in UTF-8.
     #
     def percent_decode str
+      str = str.gsub(/"((?:[^"\\]|\\.)*)"/) { Regexp.last_match(1).gsub(/\\(.)/, '\1') }
       decoded_str = str.gsub(/%[0-9a-fA-F]{2}/) { |m| [m[1..-1].to_i(16)].pack "C" }
       decoded_str.force_encoding ::Encoding::UTF_8
     end
@@ -271,7 +272,7 @@ module CloudEvents
       arr = []
       utf_str = str.to_s.encode ::Encoding::UTF_8
       utf_str.each_byte do |byte|
-        if byte >= 33 && byte <= 126 && byte != 37
+        if byte >= 33 && byte <= 126 && byte != 34 && byte != 37
           arr << byte
         else
           hi = byte / 16

--- a/test/test_http_binding.rb
+++ b/test/test_http_binding.rb
@@ -14,8 +14,10 @@ describe CloudEvents::HttpBinding do
   let(:my_source_string) { "/my_source" }
   let(:my_source) { URI.parse my_source_string }
   let(:my_type) { "my_type" }
-  let(:weird_type) { "¡Hola!\n100% 😀 " }
-  let(:encoded_weird_type) { "%C2%A1Hola!%0A100%25%20%F0%9F%98%80%20" }
+  let(:weird_type) { "¡Hola!\n\"100%\" 😀 " }
+  let(:encoded_weird_type) { "%C2%A1Hola!%0A%22100%25%22%20%F0%9F%98%80%20" }
+  let(:quoted_type) { "Hello Ruby world this\"is\\a1string okay" }
+  let(:encoded_quoted_type) { "Hello%20\"Ruby%20world\"%20\"this\\\"is\\\\a\\1string\"%20okay" }
   let(:spec_version) { "1.0" }
   let(:my_simple_data) { "12345" }
   let(:my_content_type_string) { "text/plain; charset=us-ascii" }
@@ -60,6 +62,11 @@ describe CloudEvents::HttpBinding do
   it "percent-decodes a string with special characters" do
     str = http_binding.percent_decode encoded_weird_type
     assert_equal weird_type, str
+  end
+
+  it "percent-decodes a string with quoted tokens" do
+    str = http_binding.percent_decode encoded_quoted_type
+    assert_equal quoted_type, str
   end
 
   it "decodes a structured rack env and re-encodes as batch" do


### PR DESCRIPTION
Signed-off-by: Daniel Azuma <dazuma@google.com>