### PR TITLE
fix!: Properly handle data when the content-type indicates JSON

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_gem:
   google-style: google-style.yml
 
+Lint/UnusedMethodArgument:
+  Exclude:
+    - "lib/cloud_events/format.rb"
 Metrics/BlockLength:
   Exclude:
     - "test/**/test_*.rb"

--- a/lib/cloud_events.rb
+++ b/lib/cloud_events.rb
@@ -3,6 +3,7 @@
 require "cloud_events/content_type"
 require "cloud_events/errors"
 require "cloud_events/event"
+require "cloud_events/format"
 require "cloud_events/http_binding"
 require "cloud_events/json_format"
 

--- a/lib/cloud_events/errors.rb
+++ b/lib/cloud_events/errors.rb
@@ -8,6 +8,13 @@ module CloudEvents
   end
 
   ##
+  # An error signaling that a protocol handler does not believe that a piece of
+  # data is intended to be a CloudEvent.
+  #
+  class NotCloudEventError < ::StandardError
+  end
+
+  ##
   # Errors indicating unsupported or incorrectly formatted HTTP content or
   # headers.
   #

--- a/lib/cloud_events/format.rb
+++ b/lib/cloud_events/format.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+
+module CloudEvents
+  ##
+  # This module documents the method signatures that may be implemented by
+  # formatters.
+  #
+  # Note that a formatter need not implement all methods. For example, an event
+  # formatter should implement `decode_event` and `encode_event`, and may also
+  # implement `decode_batch` and `encode_batch`, but might not implement
+  # `decode_data` or `encode_data`. Additionally, this module itself is present
+  # primarily for documentation, and need not be directly included by
+  # implementations.
+  #
+  module Format
+    ##
+    # Decode an event from the given serialized input.
+    #
+    # The arguments comprise an input string representing the encoded event
+    # from a protocol source such as an HTTP request body, and a ContentType.
+    # All additional arguments are optional, and may or may not be considered
+    # by the formatter.
+    #
+    # The formatter must return either an event object, or `nil` to signal that
+    # the formatter does not recognize the input and believes it should be
+    # handled by a different formatter.
+    # It can also raise an error to indicate that it believes it should handle
+    # the input, but that the data is malformed.
+    #
+    # @param input [String] The input as a string.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [CloudEvents::Event] if decoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def decode_event input, content_type, **_other_kwargs
+      nil
+    end
+
+    ##
+    # Encode an event to a string.
+    #
+    # The input must be a CloudEvent object. All additional arguments are
+    # optional, and may or may not be considered by the formatter.
+    #
+    # The formatter must return either a tuple comprising the serialized form
+    # of the event and an associated ContentType, or `nil` to signal that the
+    # formatter is incapable of handling the given event and believes it should
+    # be handled by a different formatter.
+    # It can also raise an error to indicate that it believes it should handle
+    # the input, but that the input is malformed.
+    #
+    # Implementations should make sure the encoding of the returned string is
+    # correct. In particular, if the format uses binary data, the returned
+    # string should have the appropriate `ASCII_8BIT` encoding, and the
+    # returned ContentType should specify the appropriate charset.
+    #
+    # @param event [CloudEvents::Event] The input event.
+    # @return [Array(String,CloudEvents::ContentType)] if encoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def encode_event event, **_other_kwargs
+      nil
+    end
+
+    ##
+    # Decode a batch of events from the given serialized input.
+    #
+    # The arguments comprise an input string representing the encoded batch of
+    # events from a protocol source such as an HTTP request body, and a
+    # ContentType. All additional arguments are optional, and may or may not be
+    # considered by the formatter.
+    #
+    # The formatter must return either an array (possibly empty) of event
+    # objects, or `nil` to signal that the formatter does not recognize the
+    # input and believes it should be handled by a different formatter.
+    # It can also raise an error to indicate that it believes it should handle
+    # the input, but that the data is malformed.
+    #
+    # @param input [String] The input as a string.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [Array<CloudEvents::Event>] if decoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def decode_batch input, content_type, **_other_kwargs
+      nil
+    end
+
+    ##
+    # Encode a batch of events to a string.
+    #
+    # The input must be an array of CloudEvent objects (which could be empty).
+    # All additional arguments are optional, and may or may not be considered
+    # by the formatter.
+    #
+    # The formatter must return either a tuple comprising the serialized form
+    # of the batch and an associated ContentType, or `nil` to signal that the
+    # formatter is incapable of handling the given batch and believes it should
+    # be handled by a different formatter.
+    # It can also raise an error to indicate that it believes it should handle
+    # the input, but that the input is malformed.
+    #
+    # Implementations should make sure the encoding of the returned string is
+    # correct. In particular, if the format uses binary data, the returned
+    # string should have the appropriate `ASCII_8BIT` encoding, and the
+    # returned ContentType should specify the appropriate charset.
+    #
+    # @param events [Array<CloudEvents::Event>] An array of input events.
+    # @return [Array(String,CloudEvents::ContentType)] if encoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def encode_batch events, **_other_kwargs
+      nil
+    end
+
+    ##
+    # Decode an event data object from string format.
+    #
+    # The arguments comprise an input string representing the encoded data from
+    # a protocol source such as an HTTP request body, and a ContentType. All
+    # additional arguments are optional, and may or may not be considered by
+    # the formatter.
+    #
+    # The formatter must return either a tuple comprising the event data object
+    # and a final ContentType (which may be the same as the input ContentType),
+    # or `nil` to signal that the formatter does not recognize the input and
+    # believes it should be handled by a different formatter.
+    # It can also raise an error to indicate that it believes it should handle
+    # the input, but that the input is malformed.
+    #
+    # @param data [String] The input data string.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [Array(Object,CloudEvents::ContentType)] if decoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def decode_data data, content_type, **_other_kwargs
+      nil
+    end
+
+    ##
+    # Encode an event data object to string format.
+    #
+    # The arguments comprise an object representing the event data, and a
+    # suggested ContentType. All additional arguments are optional, and may or
+    # may not be considered by the formatter.
+    #
+    # The formatter must return either a tuple comprising the encoded data
+    # string and a final ContentType (which may be the same as the input
+    # ContentType), or `nil` to signal that the formatter is incapable of
+    # handling the given data object and believes it should be handled by a
+    # different formatter.
+    # It can also raise an error to indicate that it believes it should handle
+    # the input, but that the input is malformed.
+    #
+    # @param data [Object] A data object to encode.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [Array(String,CloudEvents::ContentType)] if encoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def encode_data data, content_type, **_other_kwargs
+      nil
+    end
+  end
+end

--- a/lib/cloud_events/json_format.rb
+++ b/lib/cloud_events/json_format.rb
@@ -15,58 +15,125 @@ module CloudEvents
     ##
     # Decode an event from the given input JSON string.
     #
-    # @param json [String] A JSON-formatted string
-    # @return [CloudEvents::Event]
+    # See {CloudEvents::Format#decode_event} for details.
+    # This formatter determines whether to operate by checking the subtype
+    # format.
     #
-    def decode json, **_other_kwargs
-      structure = ::JSON.parse json
+    # @param input [String] The input as a string.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [CloudEvents::Event] if decoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def decode_event input, content_type, **_other_kwargs
+      return nil unless content_type&.subtype_format == "json"
+      structure = ::JSON.parse input
       decode_hash_structure structure
     end
 
     ##
     # Encode an event to a JSON string.
     #
-    # @param event [CloudEvents::Event] An input event.
-    # @param sort [boolean] Whether to sort keys of the JSON output.
-    # @return [String] The JSON representation.
+    # See {CloudEvents::Format#encode_event} for details.
     #
-    def encode event, sort: false, **_other_kwargs
+    # @param event [CloudEvents::Event] The input event.
+    # @param sort [boolean] Whether to sort keys of the JSON output.
+    # @return [Array(String,CloudEvents::ContentType)] if encoding succeeded.
+    #
+    def encode_event event, sort: false, **_other_kwargs
       structure = encode_hash_structure event
       structure = sort_keys structure if sort
-      ::JSON.dump structure
+      str = ::JSON.dump structure
+      content_type = ContentType.new "application/cloudevents+json; charset=#{charset_of str}"
+      [str, content_type]
     end
 
     ##
-    # Decode a batch of events from the given input string.
+    # Decode a batch of events from the given input JSON string.
     #
-    # @param json [String] A JSON-formatted string
-    # @return [Array<CloudEvents::Event>]
+    # See {CloudEvents::Format#decode_batch} for details.
+    # This formatter determines whether to operate by checking the subtype
+    # format.
     #
-    def decode_batch json, **_other_kwargs
-      structure_array = Array(::JSON.parse(json))
+    # @param input [String] The input as a string.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [Array<CloudEvents::Event>] if decoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def decode_batch input, content_type, **_other_kwargs
+      return nil unless content_type&.subtype_format == "json"
+      structure_array = Array(::JSON.parse(input))
       structure_array.map do |structure|
         decode_hash_structure structure
       end
     end
 
     ##
-    # Encode a batch of event to a JSON string.
+    # Encode a batch of events to a JSON formatted string.
+    #
+    # See {CloudEvents::Format#encode_batch} for details.
     #
     # @param events [Array<CloudEvents::Event>] An array of input events.
     # @param sort [boolean] Whether to sort keys of the JSON output.
-    # @return [String] The JSON representation.
+    # @return [Array(String,CloudEvents::ContentType)] if encoding succeeded.
     #
     def encode_batch events, sort: false, **_other_kwargs
       structure_array = Array(events).map do |event|
         structure = encode_hash_structure event
         sort ? sort_keys(structure) : structure
       end
-      ::JSON.dump structure_array
+      str = ::JSON.dump structure_array
+      content_type = ContentType.new "application/cloudevents-batch+json; charset=#{charset_of str}"
+      [str, content_type]
+    end
+
+    ##
+    # Decode an event data object from a JSON formatted string.
+    #
+    # See {CloudEvents::Format#decode_data} for details.
+    # This formatter determines whether to operate by checking the given
+    # content type for JSON subtype markers.
+    #
+    # @param data [String] The input data string.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @return [Array(Object,CloudEvents::ContentType)] if decoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def decode_data data, content_type, **_other_kwargs
+      return nil unless content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
+      [::JSON.parse(data), content_type]
+    end
+
+    ##
+    # Encode an event data object to a JSON formatted string.
+    #
+    # See {CloudEvents::Format#encode_data} for details.
+    # The input is a Ruby object that can be interpreted as JSON. Most Ruby
+    # objects will work, but normally it will be a JSON value type comprising
+    # hashes, arrays, strings, numbers, booleans, or nil.
+    # This formatter determines whether to operate by checking the given
+    # content type for JSON subtype markers.
+    #
+    # @param data [Object] A data object to encode.
+    # @param content_type [CloudEvents::ContentType,nil] The input content
+    #     type, or `nil` if none is available.
+    # @param sort [boolean] Whether to sort keys of the JSON output.
+    # @return [Array(String,CloudEvents::ContentType)] if encoding succeeded.
+    # @return [nil] if a different formatter should be used.
+    #
+    def encode_data data, content_type, sort: false, **_other_kwargs
+      return nil unless content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
+      data = sort_keys data if sort
+      [::JSON.dump(data), content_type]
     end
 
     ##
     # Decode a single event from a hash data structure with keys and types
     # conforming to the JSON envelope.
+    #
+    # @private
     #
     # @param structure [Hash] An input hash.
     # @return [CloudEvents::Event]
@@ -87,6 +154,8 @@ module CloudEvents
     # Encode a single event to a hash data structure with keys and types
     # conforming to the JSON envelope.
     #
+    # @private
+    #
     # @param event [CloudEvents::Event] An input event.
     # @return [String] The hash structure.
     #
@@ -103,20 +172,29 @@ module CloudEvents
 
     private
 
-    def sort_keys hash
+    def sort_keys obj
+      return obj unless obj.is_a? ::Hash
       result = {}
-      hash.keys.sort.each do |key|
-        result[key] = hash[key]
+      obj.keys.sort.each do |key|
+        result[key] = sort_keys obj[key]
       end
       result
     end
 
+    def charset_of str
+      encoding = str.encoding
+      if encoding == ::Encoding::ASCII_8BIT
+        "binary"
+      else
+        encoding.name.downcase
+      end
+    end
+
     def decode_hash_structure_v0 structure
       data = structure["data"]
-      content_type = structure["datacontenttype"]
-      if data.is_a?(::String) && content_type.is_a?(::String)
-        content_type = ContentType.new content_type
-        if content_type.subtype == "json" || content_type.subtype_format == "json"
+      if data.is_a? ::String
+        content_type = ContentType.new structure["datacontenttype"] rescue nil
+        if content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
           structure = structure.dup
           structure["data"] = ::JSON.parse data rescue data
           structure["datacontenttype"] = content_type
@@ -129,6 +207,7 @@ module CloudEvents
       if structure.key? "data_base64"
         structure = structure.dup
         structure["data"] = ::Base64.decode64 structure.delete "data_base64"
+        structure["datacontenttype"] ||= "application/octet-stream"
       end
       Event::V1.new attributes: structure
     end
@@ -137,8 +216,7 @@ module CloudEvents
       structure = event.to_h
       data = event.data
       content_type = event.data_content_type
-      if data.is_a?(::String) && !content_type.nil? &&
-         (content_type.subtype == "json" || content_type.subtype_format == "json")
+      if data.is_a?(::String) && (content_type&.subtype_base == "json" || content_type&.subtype_format == "json")
         structure["data"] = ::JSON.parse data rescue data
       end
       structure

--- a/test/test_http_binding.rb
+++ b/test/test_http_binding.rb
@@ -20,8 +20,11 @@ describe CloudEvents::HttpBinding do
   let(:encoded_quoted_type) { "Hello%20\"Ruby%20world\"%20\"this\\\"is\\\\a\\1string\"%20okay" }
   let(:spec_version) { "1.0" }
   let(:my_simple_data) { "12345" }
+  let(:my_json_escaped_simple_data) { '"12345"' }
   let(:my_content_type_string) { "text/plain; charset=us-ascii" }
   let(:my_content_type) { CloudEvents::ContentType.new my_content_type_string }
+  let(:my_json_content_type_string) { "application/json; charset=us-ascii" }
+  let(:my_json_content_type) { CloudEvents::ContentType.new my_json_content_type_string }
   let(:my_schema_string) { "/my_schema" }
   let(:my_schema) { URI.parse my_schema_string }
   let(:my_subject) { "my_subject" }
@@ -43,6 +46,20 @@ describe CloudEvents::HttpBinding do
   end
   let(:my_json_struct_encoded) { JSON.dump my_json_struct }
   let(:my_json_batch_encoded) { JSON.dump [my_json_struct] }
+  let :my_json_data_struct do
+    {
+      "data"            => my_simple_data,
+      "datacontenttype" => my_json_content_type_string,
+      "dataschema"      => my_schema_string,
+      "id"              => my_id,
+      "source"          => my_source_string,
+      "specversion"     => spec_version,
+      "subject"         => my_subject,
+      "time"            => my_time_string,
+      "type"            => my_type
+    }
+  end
+  let(:my_json_data_struct_encoded) { JSON.dump my_json_data_struct }
 
   it "percent-encodes an ascii string" do
     str = http_binding.percent_encode my_simple_data
@@ -146,6 +163,63 @@ describe CloudEvents::HttpBinding do
     headers, body = http_binding.encode_structured_content event, "json", sort: true
     assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
     assert_equal my_json_struct_encoded, body
+  end
+
+  it "decodes a structured JSON rack env and re-encodes as binary" do
+    env = {
+      "rack.input"   => StringIO.new(my_json_data_struct_encoded),
+      "CONTENT_TYPE" => "application/cloudevents+json"
+    }
+    event = http_binding.decode_rack_env env
+    assert_equal my_id, event.id
+    assert_equal my_source, event.source
+    assert_equal my_type, event.type
+    assert_equal spec_version, event.spec_version
+    assert_equal my_simple_data, event.data
+    assert_equal my_json_content_type, event.data_content_type
+    assert_equal my_schema, event.data_schema
+    assert_equal my_subject, event.subject
+    assert_equal my_time, event.time
+    headers, body = http_binding.encode_binary_content event
+    expected_headers = {
+      "CE-id"          => my_id,
+      "CE-source"      => my_source_string,
+      "CE-type"        => my_type,
+      "CE-specversion" => spec_version,
+      "Content-Type"   => my_json_content_type_string,
+      "CE-dataschema"  => my_schema_string,
+      "CE-subject"     => my_subject,
+      "CE-time"        => my_time_string
+    }
+    assert_equal expected_headers, headers
+    assert_equal my_json_escaped_simple_data, body
+  end
+
+  it "decodes a binary JSON rack env and re-encodes as structured" do
+    env = {
+      "rack.input"          => StringIO.new(my_json_escaped_simple_data),
+      "HTTP_CE_ID"          => my_id,
+      "HTTP_CE_SOURCE"      => my_source_string,
+      "HTTP_CE_TYPE"        => my_type,
+      "HTTP_CE_SPECVERSION" => spec_version,
+      "CONTENT_TYPE"        => my_json_content_type_string,
+      "HTTP_CE_DATASCHEMA"  => my_schema_string,
+      "HTTP_CE_SUBJECT"     => my_subject,
+      "HTTP_CE_TIME"        => my_time_string
+    }
+    event = http_binding.decode_rack_env env
+    assert_equal my_id, event.id
+    assert_equal my_source, event.source
+    assert_equal my_type, event.type
+    assert_equal spec_version, event.spec_version
+    assert_equal my_simple_data, event.data
+    assert_equal my_json_content_type, event.data_content_type
+    assert_equal my_schema, event.data_schema
+    assert_equal my_subject, event.subject
+    assert_equal my_time, event.time
+    headers, body = http_binding.encode_structured_content event, "json", sort: true
+    assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
+    assert_equal my_json_data_struct_encoded, body
   end
 
   it "decodes a binary rack env using an InputWrapper and re-encodes as structured" do


### PR DESCRIPTION
Previously, if the `datacontenttype` indicated JSON, the HTTP Binary decoder would not parse it but create CE objects containing the JSON-formatted string. This was inconsistent with the behavior of JSON structured decoding, and also caused incorrect round-tripping of JSON data content if the data was a JSON string rather than a JSON object.

This PR:

* Fixes the HTTP-Binary decoder so it parses JSON content-types and exposes the `data` attribute as a JSON value.
* Ensures that a CE with a string-valued `data` attribute and a JSON content-type, is semantically treated as a JSON string, and is "serialized" as such when encoding as HTTP-Binary.
* Updates the HTTP-Binary decoder so it raises the new `CloudEvents::NotCloudEventError` (rather than returning `nil`) if given an HTTP request that does not appear to be a CloudEvent. This is a breaking change.

It also makes some adjustments to the format interface, standardizing and documenting the interface, transferring responsibility for content type handling to the format object, and adjusting JsonFormat to conform. It also makes some lower-level conversion methods in HttpBinding private. These involve breaking changes to some public interfaces, but not ones that are expected to be in widespread use at this point.

See also https://github.com/cloudevents/spec/issues/558