### PR TITLE
feat!: Decode returns opaque event objects when a formatter is not available

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,9 +8,9 @@ Metrics/BlockLength:
   Exclude:
     - "test/**/test_*.rb"
 Metrics/ClassLength:
-  Max: 200
+  Max: 250
 Metrics/ModuleLength:
-  Max: 200
+  Max: 250
 Naming/FileName:
   Exclude:
     - "examples/*/Gemfile"

--- a/lib/cloud_events/content_type.rb
+++ b/lib/cloud_events/content_type.rb
@@ -25,7 +25,7 @@ module CloudEvents
     #     specified. Defaults to `us-ascii`.
     #
     def initialize string, default_charset: nil
-      @string = string
+      @string = string.to_s
       @media_type = "text"
       @subtype_base = @subtype = "plain"
       @subtype_format = nil

--- a/lib/cloud_events/errors.rb
+++ b/lib/cloud_events/errors.rb
@@ -8,28 +8,54 @@ module CloudEvents
   end
 
   ##
-  # An error signaling that a protocol handler does not believe that a piece of
-  # data is intended to be a CloudEvent.
+  # An error raised when a protocol binding was asked to decode a CloudEvent
+  # from input data, but does not believe that the data was intended to be a
+  # CloudEvent. For example, the HttpBinding might raise this exception if
+  # given a request that has neither the requisite headers for binary content
+  # mode, nor an appropriate content-type for structured content mode.
   #
-  class NotCloudEventError < ::StandardError
+  class NotCloudEventError < CloudEventsError
   end
 
   ##
-  # Errors indicating unsupported or incorrectly formatted HTTP content or
-  # headers.
+  # An error raised when a protocol binding was asked to decode a CloudEvent
+  # from input data, and the data appears to be a CloudEvent, but was encoded
+  # in a format that is not supported. Some protocol bindings can be configured
+  # to return a {CloudEvents::Event::Opaque} object instead of raising this
+  # error.
   #
-  class HttpContentError < CloudEventsError
+  class UnsupportedFormatError < CloudEventsError
   end
 
   ##
-  # Errors indicating an unsupported or incorrect spec version.
+  # An error raised when a protocol binding was asked to decode a CloudEvent
+  # from input data, and the data appears to be intended as a CloudEvent, but
+  # has unrecoverable format or syntax errors. This error _may_ have a `cause`
+  # such as a `JSON::ParserError` with additional information.
+  #
+  class FormatSyntaxError < CloudEventsError
+  end
+
+  ##
+  # An error raised when a `specversion` is set to a value not recognized or
+  # supported by the SDK.
   #
   class SpecVersionError < CloudEventsError
   end
 
   ##
-  # Errors related to CloudEvent attributes.
+  # An error raised when a malformed CloudEvents attribute is encountered,
+  # often because a required attribute is missing, or a value does not match
+  # the attribute's type specification.
   #
   class AttributeError < CloudEventsError
   end
+
+  ##
+  # Alias of UnsupportedFormatError, for backward compatibility.
+  #
+  # @deprecated Will be removed in version 1.0.
+  # @private
+  #
+  HttpContentError = UnsupportedFormatError
 end

--- a/lib/cloud_events/event.rb
+++ b/lib/cloud_events/event.rb
@@ -3,7 +3,7 @@
 require "date"
 require "uri"
 
-require "cloud_events/event/field_interpreter"
+require "cloud_events/event/opaque"
 require "cloud_events/event/v0"
 require "cloud_events/event/v1"
 

--- a/lib/cloud_events/event/opaque.rb
+++ b/lib/cloud_events/event/opaque.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module CloudEvents
+  module Event
+    ##
+    # This object represents opaque event data that arrived in structured
+    # content mode but was not in a recognized format. It may represent a
+    # single event or a batch of events.
+    #
+    # The event data is retained in a form that can be reserialized (in a
+    # structured cotent mode in the same format) but cannot otherwise be
+    # inspected.
+    #
+    # This object is immutable, and Ractor-shareable on Ruby 3.
+    #
+    class Opaque
+      ##
+      # Create an opaque object wrapping the given content and a content type.
+      #
+      # @param content [String] The opaque serialized event data.
+      # @param content_type [CloudEvents::ContentType,nil] The content type,
+      #     or `nil` if there is no content type.
+      # @param batch [boolean] Whether this represents a batch. If set to `nil`
+      #     or not provided, the value will be inferred from the content type
+      #     if possible, or otherwise set to `nil` indicating not known.
+      #
+      def initialize content, content_type, batch: nil
+        @content = content.freeze
+        @content_type = content_type
+        if batch.nil? && content_type&.media_type == "application"
+          case content_type.subtype_base
+          when "cloudevents"
+            batch = false
+          when "cloudevents-batch"
+            batch = true
+          end
+        end
+        @batch = batch
+        freeze
+      end
+
+      ##
+      # The opaque serialized event data
+      #
+      # @return [String]
+      #
+      attr_reader :content
+
+      ##
+      # The content type, or `nil` if there is no content type.
+      #
+      # @return [CloudEvents::ContentType,nil]
+      #
+      attr_reader :content_type
+
+      ##
+      # Whether this represents a batch, or `nil` if not known.
+      #
+      # @return [boolean,nil]
+      #
+      def batch?
+        @batch
+      end
+
+      ## @private
+      def == other
+        Opaque === other &&
+          @content == other.content &&
+          @content_type == other.content_type &&
+          @batch == other.batch?
+      end
+      alias eql? ==
+
+      ## @private
+      def hash
+        @content.hash ^ @content_type.hash ^ @batch.hash
+      end
+    end
+  end
+end

--- a/lib/cloud_events/json_format.rb
+++ b/lib/cloud_events/json_format.rb
@@ -29,6 +29,8 @@ module CloudEvents
       return nil unless content_type&.subtype_format == "json"
       structure = ::JSON.parse input
       decode_hash_structure structure
+    rescue ::JSON::JSONError
+      raise CloudEvents::FormatSyntaxError, "JSON syntax error"
     end
 
     ##
@@ -67,6 +69,8 @@ module CloudEvents
       structure_array.map do |structure|
         decode_hash_structure structure
       end
+    rescue ::JSON::JSONError
+      raise CloudEvents::FormatSyntaxError, "JSON syntax error"
     end
 
     ##
@@ -104,6 +108,8 @@ module CloudEvents
     def decode_data data, content_type, **_other_kwargs
       return nil unless content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
       [::JSON.parse(data), content_type]
+    rescue ::JSON::JSONError
+      raise CloudEvents::FormatSyntaxError, "JSON syntax error"
     end
 
     ##
@@ -193,7 +199,7 @@ module CloudEvents
     def decode_hash_structure_v0 structure
       data = structure["data"]
       if data.is_a? ::String
-        content_type = ContentType.new structure["datacontenttype"] rescue nil
+        content_type = ContentType.new structure["datacontenttype"]
         if content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
           structure = structure.dup
           structure["data"] = ::JSON.parse data rescue data

--- a/test/event/test_opaque.rb
+++ b/test/event/test_opaque.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+
+describe CloudEvents::Event::Opaque do
+  let(:my_content_type_string) { "text/plain; charset=us-ascii" }
+  let(:my_content_type) { CloudEvents::ContentType.new my_content_type_string }
+  let(:my_content) { "12345" }
+
+  it "handles non-batch" do
+    event = CloudEvents::Event::Opaque.new my_content, my_content_type
+    assert_equal my_content, event.content
+    assert_equal my_content_type, event.content_type
+    refute event.batch?
+    assert Ractor.shareable? event if defined? Ractor
+  end
+
+  it "handles batch" do
+    event = CloudEvents::Event::Opaque.new my_content, my_content_type, batch: true
+    assert_equal my_content, event.content
+    assert_equal my_content_type, event.content_type
+    assert event.batch?
+    assert Ractor.shareable? event if defined? Ractor
+  end
+
+  it "checks equality" do
+    event1 = CloudEvents::Event::Opaque.new my_content, my_content_type
+    event2 = CloudEvents::Event::Opaque.new my_content, my_content_type
+    event3 = CloudEvents::Event::Opaque.new my_content, my_content_type, batch: true
+    assert_equal event1, event2
+    refute_equal event1, event3
+  end
+end


### PR DESCRIPTION
* Added a class for opaque event data
* Added an option to tell `HttpBinding#decode_rack_env` to return an opaque object if the format isn't recognized
* Deprecated the `HttpContentError` class and instead introduced `UnsupportedFormatError`, to keep error classes binding-agnostic.
* Introduced `FormatSyntaxError` to report parsing errors during decoding. These were previously reported as raw JSON errors. (The JSON errors are still set as the `cause`.)
* Introduced `HttpBinding#encode_event` as a single entrypoint for encoding. Deprecated `encode_structured_content`, `encode_batched_content`, and `encode_binary_content`.

Signed-off-by: Daniel Azuma <dazuma@google.com>