### PR TITLE
fix: Set application/json by default when using json structured format

### DIFF
--- a/lib/cloud_events/errors.rb
+++ b/lib/cloud_events/errors.rb
@@ -54,8 +54,7 @@ module CloudEvents
   ##
   # Alias of UnsupportedFormatError, for backward compatibility.
   #
-  # @deprecated Will be removed in version 1.0.
-  # @private
+  # @deprecated Will be removed in version 1.0. Use {UnsupportedFormatError}.
   #
   HttpContentError = UnsupportedFormatError
 end

--- a/test/test_http_binding.rb
+++ b/test/test_http_binding.rb
@@ -272,10 +272,11 @@ describe CloudEvents::HttpBinding do
       "CE-id"          => my_id,
       "CE-source"      => my_source_string,
       "CE-type"        => my_type,
-      "CE-specversion" => spec_version
+      "CE-specversion" => spec_version,
+      "Content-Type"   => "text/plain; charset=us-ascii"
     }
     assert_equal expected_headers, headers
-    assert_nil body
+    assert_equal "", body
   end
 
   it "decodes and re-encodes binary, passing through extension headers" do


### PR DESCRIPTION
* The JSON formatter sets `datacontenttype` explicitly to `application/json` if it was previously unset.
* Further simplified and genericized the Format interface.