### PR TITLE
feat: Provide data_encoded and additional data methods on the V1 event object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,9 +8,9 @@ Metrics/BlockLength:
   Exclude:
     - "test/**/test_*.rb"
 Metrics/ClassLength:
-  Max: 250
+  Max: 300
 Metrics/ModuleLength:
-  Max: 250
+  Max: 300
 Naming/FileName:
   Exclude:
     - "examples/*/Gemfile"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ require "cloud_events"
 cloud_events_http = CloudEvents::HttpBinding.default
 
 post "/" do
-  event = cloud_events_http.decode_rack_env request.env
+  event = cloud_events_http.decode_event request.env
   logger.info "Received CloudEvent: #{event.to_h}"
 end
 ```

--- a/lib/cloud_events.rb
+++ b/lib/cloud_events.rb
@@ -6,6 +6,7 @@ require "cloud_events/event"
 require "cloud_events/format"
 require "cloud_events/http_binding"
 require "cloud_events/json_format"
+require "cloud_events/text_format"
 
 ##
 # CloudEvents implementation.

--- a/lib/cloud_events/event/field_interpreter.rb
+++ b/lib/cloud_events/event/field_interpreter.rb
@@ -22,11 +22,11 @@ module CloudEvents
         @attributes.freeze
       end
 
-      def string keys, required: false
+      def string keys, required: false, allow_empty: false
         object keys, required: required do |value|
           case value
           when ::String
-            raise AttributeError, "The #{keys.first} field cannot be empty" if value.empty?
+            raise AttributeError, "The #{keys.first} field cannot be empty" if value.empty? && !allow_empty
             value.freeze
             [value, value]
           else
@@ -125,7 +125,7 @@ module CloudEvents
         end
         if value == UNDEFINED
           raise AttributeError, "The #{keys.first} field is required" if required
-          return nil
+          return allow_nil ? UNDEFINED : nil
         end
         converted, raw = yield value
         @attributes[keys.first.freeze] = raw

--- a/lib/cloud_events/event/v1.rb
+++ b/lib/cloud_events/event/v1.rb
@@ -14,10 +14,29 @@ module CloudEvents
     # This object represents a complete CloudEvent, including the event data
     # and context attributes. It supports the standard required and optional
     # attributes defined in CloudEvents V1.0, and arbitrary extension
-    # attributes. All attribute values can be obtained (in their string form)
+    # attributes.
+    #
+    # Values for most attributes can be obtained in their encoded string form
     # via the {Event::V1#[]} method. Additionally, standard attributes have
-    # their own accessor methods that may return typed objects (such as
-    # `DateTime` for the `time` attribute).
+    # their own accessor methods that may return decoded Ruby objects (such as
+    # a `DateTime` object for the `time` attribute).
+    #
+    # The `data` attribute is treated specially because it is subject to
+    # arbitrary encoding governed by the `datacontenttype` attribute. Data is
+    # expressed in two related fields: {Event::V1#data} and
+    # {Event::V1#data_encoded}. The former, `data`, _may_ be an arbitrary Ruby
+    # object representing the decoded form of the data (for example, a Hash for
+    # most JSON-formatted data.) The latter, `data_encoded`, _must_, if
+    # present, be a Ruby String object representing the encoded string or
+    # byte array form of the data.
+    #
+    # When the CloudEvents Ruby SDK encodes an event for transmission, it will
+    # use the `data_encoded` field if present. Otherwise, it will attempt to
+    # encode the `data` field using any available encoder that recognizes the
+    # content-type. Currently, text and JSON types are supported. If the type
+    # is not supported, event encoding may fail. It is thus recommended that
+    # applications provide a `data_encoded` string, if the `data` object is
+    # nontrivially encoded.
     #
     # This object is immutable, and Ractor-shareable on Ruby 3. The data and
     # attribute values can be retrieved but not modified. To obtain an event
@@ -33,8 +52,13 @@ module CloudEvents
       ##
       # Create a new cloud event object with the given data and attributes.
       #
+      # ### Specifying event attributes
+      #
       # Event attributes may be presented as keyword arguments, or as a Hash
-      # passed in via the `attributes` argument (but not both).
+      # passed in via the special `:set_attributes` keyword argument (but not
+      # both). The `:set_attributes` keyword argument is useful for passing in
+      # attributes whose keys are strings rather than symbols, which some
+      # versions of Ruby will not accept as keyword arguments.
       #
       # The following standard attributes are supported and exposed as
       # attribute methods on the object.
@@ -45,11 +69,15 @@ module CloudEvents
       #  *  **:source** [`String`, `URI`] - _required_ - The event `source`
       #     field.
       #  *  **:type** [`String`] - _required_ - The event `type` field.
-      #  *  **:data** [`Object`] - _optional_ - The data associated with the
-      #     event (i.e. the `data` field).
+      #  *  **:data** [`Object`] - _optional_ - The "decoded" Ruby object form
+      #     of the event `data` field, if known. (e.g. a Hash representing a
+      #     JSON document)
+      #  *  **:data_encoded** [`String`] - _optional_ - The "encoded" string
+      #     form of the event `data` field, if known. This should be set along
+      #     with the `data_content_type`.
       #  *  **:data_content_type** (or **:datacontenttype**) [`String`,
-      #     {ContentType}] - _optional_ - The content-type for the data, if
-      #     the data is a string (i.e. the event `datacontenttype` field.)
+      #     {ContentType}] - _optional_ - The content-type for the encoded data
+      #     (i.e. the event `datacontenttype` field.)
       #  *  **:data_schema** (or **:dataschema**) [`String`, `URI`] -
       #     _optional_ - The event `dataschema` field.
       #  *  **:subject** [`String`] - _optional_ - The event `subject` field.
@@ -65,16 +93,63 @@ module CloudEvents
       # `:data` field, for example if you pass a structured hash. If this is an
       # issue, make a deep copy of objects before passing to this constructor.
       #
-      # @param attributes [Hash] The data and attributes, as a hash.
+      # ### Specifying payload data
+      #
+      # Typically you should provide _both_ the `:data` and `:data_encoded`
+      # fields, the former representing the decoded (Ruby object) form of the
+      # data, and the second providing a hint to formatters and protocol
+      # bindings for how to seralize the data. In this case, the {#data} and
+      # {#data_encoded} methods will return the corresponding values, and
+      # {#data_decoded?} will return true to indicate that {#data} represents
+      # the decoded form.
+      #
+      # If you provide _only_ the `:data` field, omitting `:data_encoded`, then
+      # the value is expected to represent the decoded (Ruby object) form of
+      # the data. The {#data} method will return this decoded value, and
+      # {#data_decoded?} will return true. The {#data_encoded} method will
+      # return nil.
+      # When serializing such an event, it will be up to the formatter or
+      # protocol binding to encode the data. This means serialization _could_
+      # fail if the formatter does not understand the data's content type.
+      # Omitting `:data_encoded` is common if the content type is JSON related
+      # (e.g. `application/json`) and the event is being encoded in JSON
+      # structured format, because the data encoding is trivial. This form can
+      # also be used when the content type is `text/*`, for which encoding is
+      # also trivial.
+      #
+      # If you provide _only_ the `:data_encoded` field, omitting `:data`, then
+      # the value is expected to represent the encoded (string) form of the
+      # data. The {#data_encoded} method will return this value. Additionally,
+      # the {#data} method will return the same _encoded_ value, and
+      # {#data_decoded?} will return false.
+      # Event objects of this form may be returned from a protocol binding when
+      # it decodes an event with a `datacontenttype` that it does not know how
+      # to interpret. Applications should query {#data_decoded?} to determine
+      # whether the {#data} method returns encoded or decoded data.
+      #
+      # If you provide _neither_ `:data` nor `:data_encoded`, the event will
+      # have no payload data. Both {#data} and {#data_encoded} will return nil,
+      # and {#data_decoded?} will return false. (Additionally, {#data?} will
+      # return false to signal the absence of any data.)
+      #
+      # @param set_attributes [Hash] The data and attributes, as a hash.
+      #     (Also available as `attributes` but this usage is deprecated.)
       # @param args [keywords] The data and attributes, as keyword arguments.
       #
-      def initialize attributes: nil, **args
-        interpreter = FieldInterpreter.new attributes || args
+      def initialize set_attributes: nil, attributes: nil, **args
+        interpreter = FieldInterpreter.new set_attributes || attributes || args
         @spec_version = interpreter.spec_version ["specversion", "spec_version"], accept: /^1(\.|$)/
         @id = interpreter.string ["id"], required: true
         @source = interpreter.uri ["source"], required: true
         @type = interpreter.string ["type"], required: true
+        @data_encoded = interpreter.string ["data_encoded"], allow_empty: true
         @data = interpreter.data_object ["data"]
+        if @data == FieldInterpreter::UNDEFINED
+          @data = @data_encoded
+          @data_decoded = false
+        else
+          @data_decoded = true
+        end
         @data_content_type = interpreter.content_type ["datacontenttype", "data_content_type"]
         @data_schema = interpreter.uri ["dataschema", "data_schema"]
         @subject = interpreter.string ["subject"]
@@ -93,8 +168,14 @@ module CloudEvents
       # @return [FunctionFramework::CloudEvents::Event]
       #
       def with **changes
-        attributes = @attributes.merge changes
-        V1.new attributes: attributes
+        changes = Utils.keys_to_strings changes
+        attributes = @attributes.dup
+        if changes.key?("data") || changes.key?("data_encoded")
+          attributes.delete "data"
+          attributes.delete "data_encoded"
+        end
+        attributes.merge! changes
+        V1.new set_attributes: attributes
       end
 
       ##
@@ -160,18 +241,60 @@ module CloudEvents
       alias specversion spec_version
 
       ##
-      # The event-specific data, or `nil` if there is no data.
+      # The event `data` field, or `nil` if there is no data.
       #
-      # Data may be one of the following types:
-      #  *  Binary data, represented by a `String` using the `ASCII-8BIT`
-      #     encoding.
-      #  *  A string in some other encoding such as `UTF-8` or `US-ASCII`.
-      #  *  Any JSON data type, such as a Boolean, Integer, Array, Hash, or
-      #     `nil`.
+      # This may return the data as an encoded string _or_ as a decoded Ruby
+      # object. The {#data_decoded?} method specifies whether the `data` value
+      # is decoded or encoded.
       #
-      # @return [Object]
+      # In most cases, {#data} returns a decoded value, unless the event was
+      # received from a source that could not decode the content. For example,
+      # most protocol bindings understand how to decode JSON, so an event
+      # received with a {#data_content_type} of `application/json` will usually
+      # return a decoded object (usually a Hash) from {#data}.
+      #
+      # See also {#data_encoded} and {#data_decoded?}.
+      #
+      # @return [Object] if containing decoded data
+      # @return [String] if containing encoded data
+      # @return [nil] if there is no data
       #
       attr_reader :data
+
+      ##
+      # The encoded string representation of the data, i.e. its raw form used
+      # when encoding an event for transmission. This may be `nil` if there is
+      # no data, or if the encoded form is not known.
+      #
+      # See also {#data}.
+      #
+      # @return [String,nil]
+      #
+      attr_reader :data_encoded
+
+      ##
+      # Indicates whether the {#data} field returns decoded data.
+      #
+      # @return [true] if {#data} returns a decoded Ruby object
+      # @return [false] if {#data} returns an encoded string or if the event
+      #     has no data.
+      #
+      def data_decoded?
+        @data_decoded
+      end
+
+      ##
+      # Indicates whether the data field is present. If there is no data,
+      # {#data} will return `nil`, and {#data_decoded?} will return false.
+      #
+      # Generally, if there is no data, the {#data_content_type} field should
+      # also be absent, but this is not enforced.
+      #
+      # @return [boolean]
+      #
+      def data?
+        !@data.nil? || @data_decoded
+      end
 
       ##
       # The optional `datacontenttype` field as a {CloudEvents::ContentType}

--- a/lib/cloud_events/json_format.rb
+++ b/lib/cloud_events/json_format.rb
@@ -30,22 +30,24 @@ module CloudEvents
     #
     # @param content [String] Serialized content to decode.
     # @param content_type [CloudEvents::ContentType] The input content type.
+    # @param data_decoder [#decode_data] Optional data field decoder, used for
+    #     non-JSON content types.
     # @return [Hash] if accepting the request.
     # @return [nil] if declining the request.
     # @raise [CloudEvents::FormatSyntaxError] if the JSON could not be parsed
     # @raise [CloudEvents::SpecVersionError] if an unsupported specversion is
     #     found.
     #
-    def decode_event content: nil, content_type: nil, **_other_kwargs
+    def decode_event content: nil, content_type: nil, data_decoder: nil, **_other_kwargs
       return nil unless content && content_type&.media_type == "application" && content_type&.subtype_format == "json"
       case content_type.subtype_base
       when "cloudevents"
-        event = decode_hash_structure ::JSON.parse(content), charset_of(content)
+        event = decode_hash_structure ::JSON.parse(content), charset: charset_of(content), data_decoder: data_decoder
         { event: event }
       when "cloudevents-batch"
         charset = charset_of content
         batch = Array(::JSON.parse(content)).map do |structure|
-          decode_hash_structure structure, charset
+          decode_hash_structure structure, charset: charset, data_decoder: data_decoder
         end
         { event_batch: batch }
       end
@@ -69,18 +71,21 @@ module CloudEvents
     #
     # @param event [CloudEvents::Event] An event to encode.
     # @param event_batch [Array<CloudEvents::Event>] An event batch to encode.
+    # @param data_encoder [#encode_data] Optional data field encoder, used for
+    #     non-JSON content types.
     # @param sort [boolean] Whether to sort keys of the JSON output.
     # @return [Hash] if accepting the request.
     # @return [nil] if declining the request.
+    # @raise [CloudEvents::FormatSyntaxError] if the JSON could not be parsed
     #
-    def encode_event event: nil, event_batch: nil, sort: false, **_other_kwargs
+    def encode_event event: nil, event_batch: nil, data_encoder: nil, sort: false, **_other_kwargs
       if event && !event_batch
-        structure = encode_hash_structure event
+        structure = encode_hash_structure event, data_encoder: data_encoder
         structure = sort_keys structure if sort
         subtype = "cloudevents"
       elsif event_batch && !event
         structure = event_batch.map do |elem|
-          structure_elem = encode_hash_structure elem
+          structure_elem = encode_hash_structure elem, data_encoder: data_encoder
           sort ? sort_keys(structure_elem) : structure_elem
         end
         subtype = "cloudevents-batch"
@@ -90,6 +95,8 @@ module CloudEvents
       content = ::JSON.dump structure
       content_type = ContentType.new "application/#{subtype}+json; charset=#{charset_of content}"
       { content: content, content_type: content_type }
+    rescue ::JSON::JSONError
+      raise FormatSyntaxError, "JSON syntax error"
     end
 
     ##
@@ -116,7 +123,7 @@ module CloudEvents
     def decode_data spec_version: nil, content: nil, content_type: nil, **_other_kwargs
       return nil unless spec_version
       return nil unless content
-      return nil unless content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
+      return nil unless json_content_type? content_type
       unless spec_version =~ /^0\.3|1(\.|$)/
         raise SpecVersionError, "Unrecognized specversion: #{spec_version}"
       end
@@ -151,7 +158,7 @@ module CloudEvents
     def encode_data spec_version: nil, data: UNSPECIFIED, content_type: nil, sort: false, **_other_kwargs
       return nil unless spec_version
       return nil if data == UNSPECIFIED
-      return nil unless content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
+      return nil unless json_content_type? content_type
       unless spec_version =~ /^0\.3|1(\.|$)/
         raise SpecVersionError, "Unrecognized specversion: #{spec_version}"
       end
@@ -164,19 +171,20 @@ module CloudEvents
     # Decode a single event from a hash data structure with keys and types
     # conforming to the JSON envelope.
     #
-    # @private
-    #
     # @param structure [Hash] An input hash.
-    # @param charset [String] The charset.
+    # @param charset [String] The charset of the original encoded JSON document
+    #     if known. Used to provide default content types.
+    # @param data_decoder [#decode_data] Optional data field decoder, used for
+    #     non-JSON content types.
     # @return [CloudEvents::Event]
     #
-    def decode_hash_structure structure, charset = nil
+    def decode_hash_structure structure, charset: nil, data_decoder: nil
       spec_version = structure["specversion"].to_s
       case spec_version
       when "0.3"
         decode_hash_structure_v0 structure, charset
       when /^1(\.|$)/
-        decode_hash_structure_v1 structure, charset
+        decode_hash_structure_v1 structure, charset, spec_version, data_decoder
       else
         raise SpecVersionError, "Unrecognized specversion: #{spec_version}"
       end
@@ -186,23 +194,27 @@ module CloudEvents
     # Encode a single event to a hash data structure with keys and types
     # conforming to the JSON envelope.
     #
-    # @private
-    #
     # @param event [CloudEvents::Event] An input event.
+    # @param data_encoder [#encode_data] Optional data field encoder, used for
+    #     non-JSON content types.
     # @return [String] The hash structure.
     #
-    def encode_hash_structure event
+    def encode_hash_structure event, data_encoder: nil
       case event
       when Event::V0
         encode_hash_structure_v0 event
       when Event::V1
-        encode_hash_structure_v1 event
+        encode_hash_structure_v1 event, data_encoder
       else
-        raise SpecVersionError, "Unrecognized specversion: #{event.spec_version}"
+        raise SpecVersionError, "Unrecognized event type: #{event.class}"
       end
     end
 
     private
+
+    def json_content_type? content_type
+      content_type&.subtype_base == "json" || content_type&.subtype_format == "json"
+    end
 
     def sort_keys obj
       return obj unless obj.is_a? ::Hash
@@ -232,18 +244,43 @@ module CloudEvents
       Event::V0.new attributes: structure
     end
 
-    def decode_hash_structure_v1 structure, charset
-      if structure.key? "data_base64"
-        structure = structure.dup
-        structure["data"] = ::Base64.decode64 structure.delete "data_base64"
-        structure["datacontenttype"] ||= "application/octet-stream"
-      elsif !structure.key? "datacontenttype"
-        structure = structure.dup
-        content_type = "application/json"
-        content_type = "#{content_type}; charset=#{charset}" if charset
-        structure["datacontenttype"] = content_type
+    def decode_hash_structure_v1 structure, charset, spec_version, data_decoder
+      unless structure.key?("data") || structure.key?("data_base64")
+        return Event::V1.new set_attributes: structure
       end
-      Event::V1.new attributes: structure
+      structure = structure.dup
+      content, content_type = retrieve_content_from_data_fields structure, charset
+      populate_data_fields_from_content structure, content, content_type, spec_version, data_decoder
+      Event::V1.new set_attributes: structure
+    end
+
+    def retrieve_content_from_data_fields structure, charset
+      if structure.key? "data_base64"
+        content = ::Base64.decode64 structure.delete "data_base64"
+        content_type = structure["datacontenttype"] || "application/octet-stream"
+      else
+        content = structure["data"]
+        content_type = structure["datacontenttype"]
+        content_type ||= charset ? "application/json; charset=#{charset}" : "application/json"
+      end
+      [content, ContentType.new(content_type)]
+    end
+
+    def populate_data_fields_from_content structure, content, content_type, spec_version, data_decoder
+      if json_content_type? content_type
+        structure["data_encoded"] = ::JSON.dump content
+        structure["data"] = content
+      else
+        structure["data_encoded"] = content = content.to_s
+        result = data_decoder&.decode_data spec_version: spec_version, content: content, content_type: content_type
+        if result
+          structure["data"] = result[:data]
+          content_type = result[:content_type]
+        else
+          structure.delete "data"
+        end
+      end
+      structure["datacontenttype"] = content_type
     end
 
     def encode_hash_structure_v0 event
@@ -252,17 +289,40 @@ module CloudEvents
       structure
     end
 
-    def encode_hash_structure_v1 event
+    def encode_hash_structure_v1 event, data_encoder
       structure = event.to_h
-      data = structure["data"]
-      if data.is_a?(::String) && data.encoding == ::Encoding::ASCII_8BIT
-        structure.delete "data"
-        structure["data_base64"] = ::Base64.encode64 data
-        structure["datacontenttype"] ||= "application/octet-stream"
+      return structure unless structure.key?("data") || structure.key?("data_encoded")
+      content_type = event.data_content_type
+      if content_type.nil? || json_content_type?(content_type)
+        encode_data_fields_for_json_content structure, event
       else
-        structure["datacontenttype"] ||= "application/json"
+        encode_data_fields_for_other_content structure, event, data_encoder
       end
       structure
+    end
+
+    def encode_data_fields_for_json_content structure, event
+      structure["data"] = ::JSON.parse event.data unless event.data_decoded?
+      structure.delete "data_encoded"
+      structure["datacontenttype"] ||= "application/json"
+    end
+
+    def encode_data_fields_for_other_content structure, event, data_encoder
+      data_encoded = structure.delete "data_encoded"
+      unless data_encoded
+        result = data_encoder&.encode_data spec_version: event.spec_version,
+                                           data: event.data,
+                                           content_type: event.data_content_type
+        raise UnsupportedFormatError, "Unable to encode data of media type #{event.data_content_type}" unless result
+        data_encoded = result[:content]
+        structure["datacontenttype"] = result[:content_type].to_s
+      end
+      if data_encoded.encoding == ::Encoding::ASCII_8BIT
+        structure["data_base64"] = ::Base64.encode64 data_encoded
+        structure.delete "data"
+      else
+        structure["data"] = data_encoded
+      end
     end
   end
 end

--- a/lib/cloud_events/text_format.rb
+++ b/lib/cloud_events/text_format.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+
+module CloudEvents
+  ##
+  # An data encoder/decoder for text content types. This handles any media type
+  # of the form `text/*` or `application/octet-stream`, and passes strings
+  # through as-is.
+  #
+  class TextFormat
+    # @private
+    UNSPECIFIED = ::Object.new.freeze
+
+    ##
+    # Trivially decode an event data string using text format.
+    # See {CloudEvents::Format#decode_data} for a general description.
+    #
+    # Expects `:content` and `:content_type` arguments, and will decline the
+    # request unless all three are provided.
+    #
+    # If decoding succeeded, returns a hash with the following keys:
+    #
+    # * `:data` (Object) The payload object to set as the `data` attribute.
+    # * `:content_type` ({CloudEvents::ContentType}) The content type to be set
+    #   as the `datacontenttype` attribute.
+    #
+    # @param content [String] Serialized content to decode.
+    # @param content_type [CloudEvents::ContentType] The input content type.
+    # @return [Hash] if accepting the request.
+    # @return [nil] if declining the request.
+    #
+    def decode_data content: nil, content_type: nil, **_other_kwargs
+      return nil unless content
+      return nil unless text_content_type? content_type
+      { data: content.to_s, content_type: content_type }
+    end
+
+    ##
+    # Trivially an event data object using text format.
+    # See {CloudEvents::Format#encode_data} for a general description.
+    #
+    # Expects `:data` and `:content_type` arguments, and will decline the
+    # request unless all three are provided.
+    # The `:data` object will be converted to a string if it is not already a
+    # string.
+    #
+    # If decoding succeeded, returns a hash with the following keys:
+    #
+    # * `:content` (String) The serialized form of the data.
+    # * `:content_type` ({CloudEvents::ContentType}) The content type for the
+    #   output.
+    #
+    # @param data [Object] A data object to encode.
+    # @param content_type [CloudEvents::ContentType] The input content type
+    # @return [Hash] if accepting the request.
+    # @return [nil] if declining the request.
+    #
+    def encode_data data: UNSPECIFIED, content_type: nil, **_other_kwargs
+      return nil if data == UNSPECIFIED
+      return nil unless text_content_type? content_type
+      { content: data.to_s, content_type: content_type }
+    end
+
+    private
+
+    def text_content_type? content_type
+      content_type&.media_type == "text" ||
+        content_type&.media_type == "application" && content_type&.subtype == "octet-stream"
+    end
+  end
+end

--- a/test/test_http_binding.rb
+++ b/test/test_http_binding.rb
@@ -61,86 +61,8 @@ describe CloudEvents::HttpBinding do
     }
   end
   let(:my_json_data_struct_encoded) { JSON.dump my_json_data_struct }
-
-  it "percent-encodes an ascii string" do
-    str = http_binding.percent_encode my_simple_data
-    assert_equal my_simple_data, str
-  end
-
-  it "percent-decodes an ascii string" do
-    str = http_binding.percent_decode my_simple_data
-    assert_equal my_simple_data, str
-  end
-
-  it "percent-encodes a string with special characters" do
-    str = http_binding.percent_encode weird_type
-    assert_equal encoded_weird_type, str
-  end
-
-  it "percent-decodes a string with special characters" do
-    str = http_binding.percent_decode encoded_weird_type
-    assert_equal weird_type, str
-  end
-
-  it "percent-decodes a string with quoted tokens" do
-    str = http_binding.percent_decode encoded_quoted_type
-    assert_equal quoted_type, str
-  end
-
-  it "decodes a structured rack env and re-encodes as batch" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_struct_encoded),
-      "CONTENT_TYPE" => "application/cloudevents+json"
-    }
-    event = http_binding.decode_event env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_event [event], structured_format: true, sort: true
-    assert_equal({ "Content-Type" => "application/cloudevents-batch+json; charset=utf-8" }, headers)
-    assert_equal my_json_batch_encoded, body
-  end
-
-  it "decodes a batch rack env and re-encodes as binary" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_batch_encoded),
-      "CONTENT_TYPE" => "application/cloudevents-batch+json"
-    }
-    events = http_binding.decode_event env
-    assert_equal 1, events.size
-    event = events.first
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_event event
-    expected_headers = {
-      "CE-id"          => my_id,
-      "CE-source"      => my_source_string,
-      "CE-type"        => my_type,
-      "CE-specversion" => spec_version,
-      "Content-Type"   => my_content_type_string,
-      "CE-dataschema"  => my_schema_string,
-      "CE-subject"     => my_subject,
-      "CE-time"        => my_time_string
-    }
-    assert_equal expected_headers, headers
-    assert_equal my_simple_data, body
-  end
-
-  it "decodes a binary rack env and re-encodes as structured" do
-    env = {
+  let :my_simple_binary_mode do
+    {
       "rack.input"          => StringIO.new(my_simple_data),
       "HTTP_CE_ID"          => my_id,
       "HTTP_CE_SOURCE"      => my_source_string,
@@ -151,53 +73,9 @@ describe CloudEvents::HttpBinding do
       "HTTP_CE_SUBJECT"     => my_subject,
       "HTTP_CE_TIME"        => my_time_string
     }
-    event = http_binding.decode_event env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_event event, structured_format: true, sort: true
-    assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
-    assert_equal my_json_struct_encoded, body
   end
-
-  it "decodes a structured JSON rack env and re-encodes as binary" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_data_struct_encoded),
-      "CONTENT_TYPE" => "application/cloudevents+json"
-    }
-    event = http_binding.decode_event env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_json_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_event event
-    expected_headers = {
-      "CE-id"          => my_id,
-      "CE-source"      => my_source_string,
-      "CE-type"        => my_type,
-      "CE-specversion" => spec_version,
-      "Content-Type"   => my_json_content_type_string,
-      "CE-dataschema"  => my_schema_string,
-      "CE-subject"     => my_subject,
-      "CE-time"        => my_time_string
-    }
-    assert_equal expected_headers, headers
-    assert_equal my_json_escaped_simple_data, body
-  end
-
-  it "decodes a binary JSON rack env and re-encodes as structured" do
-    env = {
+  let :my_json_binary_mode do
+    {
       "rack.input"          => StringIO.new(my_json_escaped_simple_data),
       "HTTP_CE_ID"          => my_id,
       "HTTP_CE_SOURCE"      => my_source_string,
@@ -208,282 +86,390 @@ describe CloudEvents::HttpBinding do
       "HTTP_CE_SUBJECT"     => my_subject,
       "HTTP_CE_TIME"        => my_time_string
     }
-    event = http_binding.decode_event env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_json_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_event event, structured_format: true, sort: true
-    assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
-    assert_equal my_json_data_struct_encoded, body
   end
-
-  it "decodes and re-encodes a binary JSON rack env using deprecated methods" do
-    env = {
-      "rack.input"          => StringIO.new(my_simple_data),
-      "HTTP_CE_ID"          => my_id,
-      "HTTP_CE_SOURCE"      => my_source_string,
-      "HTTP_CE_TYPE"        => my_type,
-      "HTTP_CE_SPECVERSION" => spec_version,
-      "CONTENT_TYPE"        => my_json_content_type_string,
-      "HTTP_CE_DATASCHEMA"  => my_schema_string,
-      "HTTP_CE_SUBJECT"     => my_subject,
-      "HTTP_CE_TIME"        => my_time_string
-    }
-    event = http_binding.decode_rack_env env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_json_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_binary_content event, sort: true
-    expected_headers = {
-      "CE-id"          => my_id,
-      "CE-source"      => my_source_string,
-      "CE-type"        => my_type,
-      "CE-specversion" => spec_version,
-      "Content-Type"   => my_json_content_type_string,
-      "CE-dataschema"  => my_schema_string,
-      "CE-subject"     => my_subject,
-      "CE-time"        => my_time_string
-    }
-    assert_equal expected_headers, headers
-    assert_equal my_simple_data, body
-  end
-
-  it "decodes a binary rack env using an InputWrapper and re-encodes as structured" do
-    env = {
-      "rack.input"          => Rack::Lint::InputWrapper.new(StringIO.new(my_simple_data)),
-      "HTTP_CE_ID"          => my_id,
-      "HTTP_CE_SOURCE"      => my_source_string,
-      "HTTP_CE_TYPE"        => my_type,
-      "HTTP_CE_SPECVERSION" => spec_version,
-      "CONTENT_TYPE"        => my_content_type_string,
-      "HTTP_CE_DATASCHEMA"  => my_schema_string,
-      "HTTP_CE_SUBJECT"     => my_subject,
-      "HTTP_CE_TIME"        => my_time_string
-    }
-    event = http_binding.decode_event env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_equal my_simple_data, event.data
-    assert_equal my_content_type, event.data_content_type
-    assert_equal my_schema, event.data_schema
-    assert_equal my_subject, event.subject
-    assert_equal my_time, event.time
-    headers, body = http_binding.encode_event event, structured_format: true, sort: true
-    assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
-    assert_equal my_json_struct_encoded, body
-  end
-
-  it "decodes and re-encodes binary, honoring optional headers" do
-    env = {
+  let :my_minimal_binary_mode do
+    {
+      "rack.input"          => StringIO.new(""),
       "HTTP_CE_ID"          => my_id,
       "HTTP_CE_SOURCE"      => my_source_string,
       "HTTP_CE_TYPE"        => my_type,
       "HTTP_CE_SPECVERSION" => spec_version
     }
-    event = http_binding.decode_event env
-    assert_equal my_id, event.id
-    assert_equal my_source, event.source
-    assert_equal my_type, event.type
-    assert_equal spec_version, event.spec_version
-    assert_nil event.data
-    assert_nil event.data_content_type
-    assert_nil event.data_schema
-    assert_nil event.subject
-    assert_nil event.time
-    headers, body = http_binding.encode_event event
-    expected_headers = {
-      "CE-id"          => my_id,
-      "CE-source"      => my_source_string,
-      "CE-type"        => my_type,
-      "CE-specversion" => spec_version,
-      "Content-Type"   => "text/plain; charset=us-ascii"
-    }
-    assert_equal expected_headers, headers
-    assert_equal "", body
   end
-
-  it "decodes and re-encodes binary, passing through extension headers" do
-    env = {
+  let :my_extensions_binary_mode do
+    {
       "rack.input"           => StringIO.new(my_simple_data),
-      "CONTENT_TYPE"         => my_content_type_string,
       "HTTP_CE_ID"           => my_id,
       "HTTP_CE_SOURCE"       => my_source_string,
       "HTTP_CE_TYPE"         => my_type,
       "HTTP_CE_SPECVERSION"  => spec_version,
+      "CONTENT_TYPE"         => my_content_type_string,
+      "HTTP_CE_DATASCHEMA"   => my_schema_string,
+      "HTTP_CE_SUBJECT"      => my_subject,
+      "HTTP_CE_TIME"         => my_time_string,
       "HTTP_CE_TRACECONTEXT" => my_trace_context
     }
-    event = http_binding.decode_event env
-    assert_equal my_trace_context, event["tracecontext"]
-    headers, body = http_binding.encode_event event
-    expected_headers = {
-      "CE-id"           => my_id,
-      "CE-source"       => my_source_string,
-      "CE-type"         => my_type,
-      "CE-specversion"  => spec_version,
-      "Content-Type"    => my_content_type_string,
-      "CE-tracecontext" => my_trace_context
-    }
-    assert_equal expected_headers, headers
-    assert_equal my_simple_data, body
   end
-
-  it "encodes and decodes binary, with non-ascii header characters" do
-    event = CloudEvents::Event.create spec_version:      spec_version,
-                                      id:                my_id,
-                                      source:            my_source,
-                                      type:              weird_type,
-                                      data:              my_simple_data,
-                                      data_content_type: my_content_type_string
-    headers, body = http_binding.encode_event event
-    expected_headers = {
-      "CE-id"          => my_id,
-      "CE-source"      => my_source_string,
-      "CE-type"        => encoded_weird_type,
-      "CE-specversion" => spec_version,
-      "Content-Type"   => my_content_type_string
-    }
-    assert_equal expected_headers, headers
-    assert_equal my_simple_data, body
-
-    env = {
-      "rack.input"          => StringIO.new(body),
-      "CONTENT_TYPE"        => my_content_type_string,
+  let :my_nonascii_binary_mode do
+    {
+      "rack.input"          => StringIO.new(my_simple_data),
       "HTTP_CE_ID"          => my_id,
       "HTTP_CE_SOURCE"      => my_source_string,
       "HTTP_CE_TYPE"        => encoded_weird_type,
-      "HTTP_CE_SPECVERSION" => spec_version
+      "HTTP_CE_SPECVERSION" => spec_version,
+      "CONTENT_TYPE"        => my_content_type_string,
+      "HTTP_CE_DATASCHEMA"  => my_schema_string,
+      "HTTP_CE_SUBJECT"     => my_subject,
+      "HTTP_CE_TIME"        => my_time_string
     }
-    reconstituted_event = http_binding.decode_event env
-    assert_equal event, reconstituted_event
+  end
+  let :my_simple_event do
+    CloudEvents::Event::V1.new data_encoded: my_simple_data,
+                               data: my_simple_data,
+                               datacontenttype: my_content_type_string,
+                               dataschema: my_schema_string,
+                               id: my_id,
+                               source: my_source_string,
+                               specversion: spec_version,
+                               subject: my_subject,
+                               time: my_time_string,
+                               type: my_type
+  end
+  let :my_json_event do
+    CloudEvents::Event::V1.new data_encoded: my_json_escaped_simple_data,
+                               data: my_simple_data,
+                               datacontenttype: my_json_content_type_string,
+                               dataschema: my_schema_string,
+                               id: my_id,
+                               source: my_source_string,
+                               specversion: spec_version,
+                               subject: my_subject,
+                               time: my_time_string,
+                               type: my_type
+  end
+  let :my_minimal_event do
+    CloudEvents::Event::V1.new data_encoded: "",
+                               data: "",
+                               id: my_id,
+                               source: my_source_string,
+                               specversion: spec_version,
+                               type: my_type
+  end
+  let :my_extensions_event do
+    CloudEvents::Event::V1.new data_encoded: my_simple_data,
+                               data: my_simple_data,
+                               datacontenttype: my_content_type_string,
+                               dataschema: my_schema_string,
+                               id: my_id,
+                               source: my_source_string,
+                               specversion: spec_version,
+                               subject: my_subject,
+                               time: my_time_string,
+                               tracecontext: my_trace_context,
+                               type: my_type
+  end
+  let :my_nonascii_event do
+    CloudEvents::Event::V1.new data_encoded: my_simple_data,
+                               data: my_simple_data,
+                               datacontenttype: my_content_type_string,
+                               dataschema: my_schema_string,
+                               id: my_id,
+                               source: my_source_string,
+                               specversion: spec_version,
+                               subject: my_subject,
+                               time: my_time_string,
+                               type: weird_type
   end
 
-  it "raises UnsupportedFormatError when a format is not recognized" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_struct_encoded),
-      "CONTENT_TYPE" => "application/cloudevents+hello"
-    }
-    assert_raises CloudEvents::UnsupportedFormatError do
-      http_binding.decode_event env
+  def assert_request_matches env, headers, body
+    env = env.dup
+    assert_equal env.delete("rack.input").read, body
+    headers_env = {}
+    headers.each do |k, v|
+      k = k.tr("-", "_").upcase
+      k = "HTTP_#{k}" unless k == "CONTENT_TYPE"
+      headers_env[k] = v
+    end
+    assert_equal env, headers_env
+  end
+
+  describe "percent_encode" do
+    it "percent-encodes an ascii string" do
+      str = http_binding.percent_encode my_simple_data
+      assert_equal my_simple_data, str
+    end
+
+    it "percent-encodes a string with special characters" do
+      str = http_binding.percent_encode weird_type
+      assert_equal encoded_weird_type, str
     end
   end
 
-  it "raises FormatSyntaxError when decoding malformed JSON event" do
-    env = {
-      "rack.input"   => StringIO.new("!!!"),
-      "CONTENT_TYPE" => "application/cloudevents+json"
-    }
-    error = assert_raises CloudEvents::FormatSyntaxError do
-      http_binding.decode_event env
+  describe "percent_decode" do
+    it "percent-decodes an ascii string" do
+      str = http_binding.percent_decode my_simple_data
+      assert_equal my_simple_data, str
     end
-    assert_kind_of JSON::ParserError, error.cause
-  end
 
-  it "raises FormatSyntaxError when decoding malformed JSON batch" do
-    env = {
-      "rack.input"   => StringIO.new("!!!"),
-      "CONTENT_TYPE" => "application/cloudevents-batch+json"
-    }
-    error = assert_raises CloudEvents::FormatSyntaxError do
-      http_binding.decode_event env
+    it "percent-decodes a string with special characters" do
+      str = http_binding.percent_decode encoded_weird_type
+      assert_equal weird_type, str
     end
-    assert_kind_of JSON::ParserError, error.cause
-  end
 
-  it "raises SpecVersionError when decoding a binary event with a bad specversion" do
-    env = {
-      "HTTP_CE_ID"          => my_id,
-      "HTTP_CE_SOURCE"      => my_source_string,
-      "HTTP_CE_TYPE"        => my_type,
-      "HTTP_CE_SPECVERSION" => "0.1"
-    }
-    assert_raises CloudEvents::SpecVersionError do
-      http_binding.decode_event env
+    it "percent-decodes a string with quoted tokens" do
+      str = http_binding.percent_decode encoded_quoted_type
+      assert_equal quoted_type, str
     end
   end
 
-  it "raises NotCloudEventError when a content-type is not recognized" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_struct_encoded),
-      "CONTENT_TYPE" => "application/json"
-    }
-    assert_raises CloudEvents::NotCloudEventError do
-      http_binding.decode_event env
+  describe "decode_event" do
+    it "decodes a json-structured rack env with text content type" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_struct_encoded),
+        "CONTENT_TYPE" => "application/cloudevents+json"
+      }
+      event = http_binding.decode_event env
+      assert_equal my_simple_event, event
+    end
+
+    it "decodes a json-structured rack env with json content type" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_data_struct_encoded),
+        "CONTENT_TYPE" => "application/cloudevents+json"
+      }
+      event = http_binding.decode_event env
+      assert_equal my_json_event, event
+    end
+
+    it "decodes a json-batch rack env with text content type" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_batch_encoded),
+        "CONTENT_TYPE" => "application/cloudevents-batch+json"
+      }
+      events = http_binding.decode_event env
+      assert_equal [my_simple_event], events
+    end
+
+    it "decodes a binary mode rack env with text content type" do
+      event = http_binding.decode_event my_simple_binary_mode
+      assert_equal my_simple_event, event
+    end
+
+    it "decodes a binary mode rack env with json content type" do
+      event = http_binding.decode_event my_json_binary_mode
+      assert_equal my_json_event, event
+    end
+
+    it "decodes a binary mode rack env using an InputWrapper" do
+      my_simple_binary_mode["rack.input"] = Rack::Lint::InputWrapper.new StringIO.new my_simple_data
+      event = http_binding.decode_event my_simple_binary_mode
+      assert_equal my_simple_event, event
+    end
+
+    it "decodes a binary mode rack env omitting optional headers" do
+      event = http_binding.decode_event my_minimal_binary_mode
+      assert_equal my_minimal_event, event
+    end
+
+    it "decodes a binary mode rack env with extension headers" do
+      event = http_binding.decode_event my_extensions_binary_mode
+      assert_equal my_extensions_event, event
+    end
+
+    it "decodes a binary mode rack env with non-ascii characters in a header" do
+      event = http_binding.decode_event my_nonascii_binary_mode
+      assert_equal my_nonascii_event, event
+    end
+
+    it "decodes a structured event using opaque" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_struct_encoded),
+        "CONTENT_TYPE" => "application/cloudevents+json"
+      }
+      event = minimal_http_binding.decode_event env, allow_opaque: true
+      assert_kind_of CloudEvents::Event::Opaque, event
+      refute event.batch?
+      assert_equal my_json_struct_encoded, event.content
+      assert_equal CloudEvents::ContentType.new("application/cloudevents+json"), event.content_type
+    end
+
+    it "decodes a structured batch using opaque" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_batch_encoded),
+        "CONTENT_TYPE" => "application/cloudevents-batch+json"
+      }
+      event = minimal_http_binding.decode_event env, allow_opaque: true
+      assert_kind_of CloudEvents::Event::Opaque, event
+      assert event.batch?
+      assert_equal my_json_batch_encoded, event.content
+      assert_equal CloudEvents::ContentType.new("application/cloudevents-batch+json"), event.content_type
+    end
+
+    it "raises UnsupportedFormatError when a format is not recognized" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_struct_encoded),
+        "CONTENT_TYPE" => "application/cloudevents+hello"
+      }
+      assert_raises CloudEvents::UnsupportedFormatError do
+        http_binding.decode_event env
+      end
+    end
+
+    it "raises FormatSyntaxError when decoding malformed JSON event" do
+      env = {
+        "rack.input"   => StringIO.new("!!!"),
+        "CONTENT_TYPE" => "application/cloudevents+json"
+      }
+      error = assert_raises CloudEvents::FormatSyntaxError do
+        http_binding.decode_event env
+      end
+      assert_kind_of JSON::ParserError, error.cause
+    end
+
+    it "raises FormatSyntaxError when decoding malformed JSON batch" do
+      env = {
+        "rack.input"   => StringIO.new("!!!"),
+        "CONTENT_TYPE" => "application/cloudevents-batch+json"
+      }
+      error = assert_raises CloudEvents::FormatSyntaxError do
+        http_binding.decode_event env
+      end
+      assert_kind_of JSON::ParserError, error.cause
+    end
+
+    it "raises SpecVersionError when decoding a binary event with a bad specversion" do
+      env = {
+        "HTTP_CE_ID"          => my_id,
+        "HTTP_CE_SOURCE"      => my_source_string,
+        "HTTP_CE_TYPE"        => my_type,
+        "HTTP_CE_SPECVERSION" => "0.1"
+      }
+      assert_raises CloudEvents::SpecVersionError do
+        http_binding.decode_event env
+      end
+    end
+
+    it "raises NotCloudEventError when a content-type is not recognized" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_struct_encoded),
+        "CONTENT_TYPE" => "application/json"
+      }
+      assert_raises CloudEvents::NotCloudEventError do
+        http_binding.decode_event env
+      end
     end
   end
 
-  it "returns nil from the legacy decode method when a content-type is not recognized" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_struct_encoded),
-      "CONTENT_TYPE" => "application/json"
-    }
-    assert_nil http_binding.decode_rack_env env
+  describe "encode_event" do
+    it "encodes an event with text contenxt type to json-structured mode" do
+      headers, body = http_binding.encode_event my_simple_event, structured_format: true, sort: true
+      assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
+      assert_equal my_json_struct_encoded, body
+    end
+
+    it "encodes an event with json contenxt type to json-structured mode" do
+      headers, body = http_binding.encode_event my_json_event, structured_format: true, sort: true
+      assert_equal({ "Content-Type" => "application/cloudevents+json; charset=utf-8" }, headers)
+      assert_equal my_json_data_struct_encoded, body
+    end
+
+    it "encodes a batch of events to json-structured mode" do
+      headers, body = http_binding.encode_event [my_simple_event], structured_format: true, sort: true
+      assert_equal({ "Content-Type" => "application/cloudevents-batch+json; charset=utf-8" }, headers)
+      assert_equal my_json_batch_encoded, body
+    end
+
+    it "encodes an event with text content type to binary mode" do
+      headers, body = http_binding.encode_event my_simple_event
+      assert_request_matches my_simple_binary_mode, headers, body
+    end
+
+    it "encodes an event with json content type to binary mode" do
+      headers, body = http_binding.encode_event my_json_event
+      assert_request_matches my_json_binary_mode, headers, body
+    end
+
+    it "encodes an event omitting optional attributes to binary mode" do
+      headers, body = http_binding.encode_event my_minimal_event
+      assert_request_matches my_minimal_binary_mode, headers, body
+    end
+
+    it "encodes an event with extension attributes to binary mode" do
+      headers, body = http_binding.encode_event my_extensions_event
+      assert_request_matches my_extensions_binary_mode, headers, body
+    end
+
+    it "encodes an event with non-ascii attribute characters to binary mode" do
+      headers, body = http_binding.encode_event my_nonascii_event
+      assert_request_matches my_nonascii_binary_mode, headers, body
+    end
+
+    it "decodes a structured event using opaque" do
+      event = CloudEvents::Event::Opaque.new my_json_struct_encoded,
+                                             CloudEvents::ContentType.new("application/cloudevents+json")
+      headers, body = minimal_http_binding.encode_event event
+      assert_equal({ "Content-Type" => "application/cloudevents+json" }, headers)
+      assert_equal my_json_struct_encoded, body
+    end
+
+    it "decodes a structured batch using opaque" do
+      event = CloudEvents::Event::Opaque.new my_json_batch_encoded,
+                                             CloudEvents::ContentType.new("application/cloudevents-batch+json")
+      headers, body = minimal_http_binding.encode_event event
+      assert_equal({ "Content-Type" => "application/cloudevents-batch+json" }, headers)
+      assert_equal my_json_batch_encoded, body
+    end
   end
 
-  it "decodes and re-encodes a structured event using opaque" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_struct_encoded),
-      "CONTENT_TYPE" => "application/cloudevents+json"
-    }
-    event = minimal_http_binding.decode_event env, allow_opaque: true
-    assert_kind_of CloudEvents::Event::Opaque, event
-    refute event.batch?
-    headers, body = minimal_http_binding.encode_event event
-    assert_equal({ "Content-Type" => "application/cloudevents+json" }, headers)
-    assert_equal my_json_struct_encoded, body
+  describe "deprecated methods" do
+    it "decodes a binary mode rack env with text content type" do
+      event = http_binding.decode_rack_env my_simple_binary_mode
+      expected_attributes = my_simple_event.to_h
+      expected_attributes.delete "data_encoded"
+      assert_equal expected_attributes, event.to_h
+    end
+
+    it "encodes an event with text contenxt type to binary mode" do
+      headers, body = http_binding.encode_binary_content my_simple_event, sort: true
+      assert_request_matches my_simple_binary_mode, headers, body
+    end
+
+    it "returns nil from the legacy decode method when a content-type is not recognized" do
+      env = {
+        "rack.input"   => StringIO.new(my_json_struct_encoded),
+        "CONTENT_TYPE" => "application/json"
+      }
+      assert_nil http_binding.decode_rack_env env
+    end
   end
 
-  it "decodes and re-encodes a batch of events using opaque" do
-    env = {
-      "rack.input"   => StringIO.new(my_json_batch_encoded),
-      "CONTENT_TYPE" => "application/cloudevents-batch+json"
-    }
-    event = minimal_http_binding.decode_event env, allow_opaque: true
-    assert_kind_of CloudEvents::Event::Opaque, event
-    assert event.batch?
-    headers, body = minimal_http_binding.encode_event event
-    assert_equal({ "Content-Type" => "application/cloudevents-batch+json" }, headers)
-    assert_equal my_json_batch_encoded, body
-  end
+  describe "probable_event?" do
+    it "detects a probable binary event" do
+      env = {
+        "HTTP_CE_SPECVERSION" => "1.0"
+      }
+      assert http_binding.probable_event? env
+    end
 
-  it "detects a probable binary event" do
-    env = {
-      "HTTP_CE_SPECVERSION" => "1.0"
-    }
-    assert http_binding.probable_event? env
-  end
+    it "detects a probable structured event" do
+      env = {
+        "CONTENT_TYPE" => "application/cloudevents+myformat"
+      }
+      assert http_binding.probable_event? env
+    end
 
-  it "detects a probable structured event" do
-    env = {
-      "CONTENT_TYPE" => "application/cloudevents+myformat"
-    }
-    assert http_binding.probable_event? env
-  end
+    it "detects a probable batch event" do
+      env = {
+        "CONTENT_TYPE" => "application/cloudevents-batch+myformat"
+      }
+      assert http_binding.probable_event? env
+    end
 
-  it "detects a probable batch event" do
-    env = {
-      "CONTENT_TYPE" => "application/cloudevents-batch+myformat"
-    }
-    assert http_binding.probable_event? env
-  end
-
-  it "detects when something is unlikely an event" do
-    env = {
-      "CONTENT_TYPE" => "application/json"
-    }
-    refute http_binding.probable_event? env
+    it "detects when something is unlikely an event" do
+      env = {
+        "CONTENT_TYPE" => "application/json"
+      }
+      refute http_binding.probable_event? env
+    end
   end
 end

--- a/test/test_json_format.rb
+++ b/test/test_json_format.rb
@@ -16,14 +16,18 @@ describe CloudEvents::JsonFormat do
   let(:my_type) { "my_type" }
   let(:my_json_data) { { "a" => 12_345, "b" => "hello", "c" => [true, false, nil] } }
   let(:my_json_string_data) { JSON.dump my_json_data }
+  let(:my_doubly_encoded_json_string_data) { JSON.dump my_json_string_data }
   let(:my_data_string) { "12345" }
   let(:my_json_encoded_data_string) { '"12345"' }
-  let(:my_base64_data) { Base64.encode64 my_data_string }
+  let(:my_base64_data) { "/w==\n" }
+  let(:my_binary_string) { Base64.decode64 my_base64_data }
   let(:my_content_encoding) { "8bit" }
   let(:my_content_type_string) { "text/plain; charset=us-ascii" }
   let(:my_content_type) { CloudEvents::ContentType.new my_content_type_string }
   let(:my_json_content_type_string) { "application/json; charset=us-ascii" }
   let(:my_json_content_type) { CloudEvents::ContentType.new my_json_content_type_string }
+  let(:my_binary_content_type_string) { "application/octet-stream" }
+  let(:my_binary_content_type) { CloudEvents::ContentType.new my_binary_content_type_string }
   let(:my_schema_string) { "/my_schema" }
   let(:my_schema) { URI.parse my_schema_string }
   let(:my_subject) { "my_subject" }
@@ -174,6 +178,43 @@ describe CloudEvents::JsonFormat do
         "type"            => my_type
       }
     end
+    let :my_json_event_v1 do
+      CloudEvents::Event::V1.new data: my_json_data,
+                                 data_encoded: my_json_string_data,
+                                 datacontenttype: my_json_content_type_string,
+                                 dataschema: my_schema_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 subject: my_subject,
+                                 time: my_time_string,
+                                 type: my_type
+    end
+    let :my_json_string_struct_v1 do
+      {
+        "data"            => my_json_string_data,
+        "datacontenttype" => my_json_content_type_string,
+        "dataschema"      => my_schema_string,
+        "id"              => my_id,
+        "source"          => my_source_string,
+        "specversion"     => spec_version_v1,
+        "subject"         => my_subject,
+        "time"            => my_time_string,
+        "type"            => my_type
+      }
+    end
+    let :my_json_string_event_v1 do
+      CloudEvents::Event::V1.new data: my_json_string_data,
+                                 data_encoded: my_doubly_encoded_json_string_data,
+                                 datacontenttype: my_json_content_type_string,
+                                 dataschema: my_schema_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 subject: my_subject,
+                                 time: my_time_string,
+                                 type: my_type
+    end
     let :my_string_struct_v1 do
       {
         "data"            => my_data_string,
@@ -187,10 +228,44 @@ describe CloudEvents::JsonFormat do
         "type"            => my_type
       }
     end
+    let :my_string_event_v1 do
+      CloudEvents::Event::V1.new data_encoded: my_data_string,
+                                 datacontenttype: my_content_type_string,
+                                 dataschema: my_schema_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 subject: my_subject,
+                                 time: my_time_string,
+                                 type: my_type
+    end
+    let :my_decoded_string_event_v1 do
+      CloudEvents::Event::V1.new data_encoded: my_data_string,
+                                 data: my_data_string,
+                                 datacontenttype: my_content_type_string,
+                                 dataschema: my_schema_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 subject: my_subject,
+                                 time: my_time_string,
+                                 type: my_type
+    end
+    let :my_nonencoded_string_event_v1 do
+      CloudEvents::Event::V1.new data: my_data_string,
+                                 datacontenttype: my_content_type_string,
+                                 dataschema: my_schema_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 subject: my_subject,
+                                 time: my_time_string,
+                                 type: my_type
+    end
     let :my_base64_struct_v1 do
       {
         "data_base64"     => my_base64_data,
-        "datacontenttype" => my_content_type_string,
+        "datacontenttype" => my_binary_content_type_string,
         "dataschema"      => my_schema_string,
         "id"              => my_id,
         "source"          => my_source_string,
@@ -200,7 +275,18 @@ describe CloudEvents::JsonFormat do
         "type"            => my_type
       }
     end
-    let :my_incomplete_struct_v1 do
+    let :my_binary_event_v1 do
+      CloudEvents::Event::V1.new data_encoded: my_binary_string,
+                                 datacontenttype: my_binary_content_type_string,
+                                 dataschema: my_schema_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 subject: my_subject,
+                                 time: my_time_string,
+                                 type: my_type
+    end
+    let :my_incomplete_struct_with_nils_v1 do
       {
         "data"            => my_json_data,
         "datacontenttype" => my_json_content_type_string,
@@ -211,6 +297,32 @@ describe CloudEvents::JsonFormat do
         "time"            => nil,
         "type"            => my_type
       }
+    end
+    let :my_incomplete_struct_v1 do
+      my_incomplete_struct_with_nils_v1.delete_if { |_k, v| v.nil? }
+    end
+    let :my_incomplete_event_v1 do
+      CloudEvents::Event::V1.new data: my_json_data,
+                                 data_encoded: my_json_string_data,
+                                 datacontenttype: my_json_content_type_string,
+                                 id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 type: my_type
+    end
+    let :my_minimal_struct_v1 do
+      {
+        "id"              => my_id,
+        "source"          => my_source_string,
+        "specversion"     => spec_version_v1,
+        "type"            => my_type
+      }
+    end
+    let :my_minimal_event_v1 do
+      CloudEvents::Event::V1.new id: my_id,
+                                 source: my_source_string,
+                                 specversion: spec_version_v1,
+                                 type: my_type
     end
     let :my_typeless_struct_v1 do
       {
@@ -226,186 +338,232 @@ describe CloudEvents::JsonFormat do
     end
     let(:my_json_struct_v1_string) { JSON.dump my_json_struct_v1 }
     let(:my_batch_v1_string) { JSON.dump [my_base64_struct_v1, my_json_struct_v1] }
-    let :my_compacted_incomplete_struct_v1 do
-      my_incomplete_struct_v1.delete_if { |_k, v| v.nil? }
-    end
 
-    it "decodes and encodes a struct with string data" do
-      event = json_format.decode_hash_structure my_string_struct_v1
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_data_string, event.data
-      assert_equal my_content_type, event.data_content_type
-      assert_equal my_schema, event.data_schema
-      assert_equal my_subject, event.subject
-      assert_equal my_time, event.time
-      struct = json_format.encode_hash_structure event
-      assert_equal my_string_struct_v1, struct
-    end
+    describe "decode_hash_structure" do
+      it "decodes a struct with string data" do
+        event = json_format.decode_hash_structure my_string_struct_v1
+        assert_equal my_string_event_v1, event
+        refute event.data_decoded?
+      end
 
-    it "decodes and encodes a struct with base64 data" do
-      event = json_format.decode_hash_structure my_base64_struct_v1
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_data_string, event.data
-      assert_equal my_content_type, event.data_content_type
-      assert_equal my_schema, event.data_schema
-      assert_equal my_subject, event.subject
-      assert_equal my_time, event.time
-      struct = json_format.encode_hash_structure event
-      assert_equal my_base64_struct_v1, struct
-    end
+      it "decodes a struct with string data and a decoder" do
+        text_decoder = CloudEvents::TextFormat.new
+        event = json_format.decode_hash_structure my_string_struct_v1, data_decoder: text_decoder
+        assert_equal my_decoded_string_event_v1, event
+        assert event.data_decoded?
+      end
 
-    it "decodes and encodes a struct with json object data" do
-      event = json_format.decode_hash_structure my_json_struct_v1
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_json_data, event.data
-      assert_equal my_json_content_type, event.data_content_type
-      assert_equal my_schema, event.data_schema
-      assert_equal my_subject, event.subject
-      assert_equal my_time, event.time
-      struct = json_format.encode_hash_structure event
-      assert_equal my_json_struct_v1, struct
-    end
+      it "decodes a struct with base64 data" do
+        event = json_format.decode_hash_structure my_base64_struct_v1
+        assert_equal my_binary_event_v1, event
+        refute event.data_decoded?
+      end
 
-    it "decodes a struct without content type" do
-      event = json_format.decode_hash_structure my_typeless_struct_v1, "us-ascii"
-      assert_equal my_json_data, event.data
-      assert_equal my_json_content_type, event.data_content_type
-    end
+      it "decodes a struct with json object data" do
+        event = json_format.decode_hash_structure my_json_struct_v1
+        assert_equal my_json_event_v1, event
+        assert event.data_decoded?
+      end
 
-    it "encodes a struct without content type" do
-      event = CloudEvents::Event.create spec_version: spec_version_v1,
-                                        id:           my_id,
-                                        source:       my_source,
-                                        type:         my_type,
-                                        data:         my_json_data
-      struct = json_format.encode_hash_structure event
-      assert_equal "application/json", struct["datacontenttype"]
-    end
+      it "decodes a struct with json string data" do
+        event = json_format.decode_hash_structure my_json_string_struct_v1
+        assert_equal my_json_string_event_v1, event
+        assert event.data_decoded?
+      end
 
-    it "decodes and encodes json-encoded content" do
-      result = json_format.decode_event content: my_json_struct_v1_string, content_type: structured_content_type
-      event = result[:event]
-      assert_kind_of CloudEvents::Event, event
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_json_data, event.data
-      assert_equal my_json_content_type, event.data_content_type
-      assert_equal my_schema, event.data_schema
-      assert_equal my_subject, event.subject
-      assert_equal my_time, event.time
-      result = json_format.encode_event event: event, sort: true
-      string = result[:content]
-      content_type = result[:content_type]
-      assert_equal my_json_struct_v1_string, string
-      assert_equal structured_content_type, content_type
-    end
+      it "decodes a struct without content type" do
+        event = json_format.decode_hash_structure my_typeless_struct_v1, charset: "us-ascii"
+        assert_equal my_json_event_v1, event
+        assert event.data_decoded?
+        assert_equal my_json_content_type, event.data_content_type
+      end
 
-    it "decodes and encodes json-encoded batch" do
-      result = json_format.decode_event content: my_batch_v1_string, content_type: batched_content_type
-      events = result[:event_batch]
-      assert_kind_of Array, events
-      assert_equal 2, events.size
-      event = events[0]
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_data_string, event.data
-      assert_equal my_content_type, event.data_content_type
-      assert_equal my_schema, event.data_schema
-      assert_equal my_subject, event.subject
-      assert_equal my_time, event.time
-      event = events[1]
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_json_data, event.data
-      assert_equal my_json_content_type, event.data_content_type
-      assert_equal my_schema, event.data_schema
-      assert_equal my_subject, event.subject
-      assert_equal my_time, event.time
-      result = json_format.encode_event event_batch: events, sort: true
-      string = result[:content]
-      content_type = result[:content_type]
-      assert_equal my_batch_v1_string, string
-      assert_equal batched_content_type, content_type
-    end
+      it "decodes a struct with nulls" do
+        event = json_format.decode_hash_structure my_incomplete_struct_with_nils_v1
+        assert_equal my_incomplete_event_v1, event
+        assert_nil event.data_schema
+        assert_nil event.subject
+        assert_nil event.time
+        hash = event.to_h
+        refute hash.include? "subject"
+        refute hash.include? "time"
+      end
 
-    it "decodes and encodes json with nulls" do
-      event = json_format.decode_hash_structure my_incomplete_struct_v1
-      assert_equal my_id, event.id
-      assert_equal my_source, event.source
-      assert_equal my_type, event.type
-      assert_equal spec_version_v1, event.spec_version
-      assert_equal my_json_data, event.data
-      assert_equal my_json_content_type, event.data_content_type
-      assert_nil event.data_schema
-      assert_nil event.subject
-      assert_nil event.time
-      hash = event.to_h
-      refute hash.include? "subject"
-      refute hash.include? "time"
-      struct = json_format.encode_hash_structure event
-      assert_equal my_compacted_incomplete_struct_v1, struct
-    end
+      it "decodes a minimal struct" do
+        event = json_format.decode_hash_structure my_minimal_struct_v1
+        assert_equal my_minimal_event_v1, event
+        refute event.data_decoded?
+      end
 
-    it "refuses to decode non-json content types" do
-      assert_nil json_format.decode_event content: my_json_struct_v1_string, content_type: my_content_type
-    end
-
-    it "raises SpecVersionError when JSON input has a bad specversion" do
-      malformed_input = {
-        "data"            => my_json_data,
-        "datacontenttype" => my_content_type_string,
-        "id"              => my_id,
-        "source"          => my_source_string,
-        "specversion"     => "0.1",
-        "type"            => my_type
-      }
-      malformed_input_string = JSON.dump malformed_input
-      assert_raises CloudEvents::SpecVersionError do
-        json_format.decode_event content: malformed_input_string, content_type: structured_content_type
+      [
+        "application/json",
+        "text/json",
+        "application/json; charset=utf-8",
+        "application/blah+json",
+        "application/blah+json; foo=bar"
+      ].each do |content_type|
+        it "recognizes #{content_type} as a json-object-data special case" do
+          my_struct = my_minimal_struct_v1.merge(
+            {
+              "data" => my_json_string_data,
+              "datacontenttype" => content_type
+            }
+          )
+          event = json_format.decode_hash_structure my_struct
+          assert_equal my_json_string_data, event.data
+          assert_equal my_doubly_encoded_json_string_data, event.data_encoded
+          assert event.data_decoded?
+        end
       end
     end
 
-    it "raises AttributeError when JSON input is missing an ID" do
-      malformed_input = {
-        "data"            => my_json_data,
-        "datacontenttype" => my_content_type_string,
-        "source"          => my_source_string,
-        "specversion"     => "1.0",
-        "type"            => my_type
-      }
-      malformed_input_string = JSON.dump malformed_input
-      assert_raises CloudEvents::AttributeError do
-        json_format.decode_event content: malformed_input_string, content_type: structured_content_type
+    describe "encode_hash_structure" do
+      it "encodes an event with string data" do
+        struct = json_format.encode_hash_structure my_string_event_v1
+        assert_equal my_string_struct_v1, struct
+      end
+
+      it "encodes an event with string data and an encoder" do
+        text_encoder = CloudEvents::TextFormat.new
+        struct = json_format.encode_hash_structure my_nonencoded_string_event_v1, data_encoder: text_encoder
+        assert_equal my_string_struct_v1, struct
+      end
+
+      it "encodes an event with binary data" do
+        struct = json_format.encode_hash_structure my_binary_event_v1
+        assert_equal my_base64_struct_v1, struct
+      end
+
+      it "encodes an event with json object data" do
+        struct = json_format.encode_hash_structure my_json_event_v1
+        assert_equal my_json_struct_v1, struct
+      end
+
+      it "encodes an event with json string data" do
+        struct = json_format.encode_hash_structure my_json_string_event_v1
+        assert_equal my_json_string_struct_v1, struct
+      end
+
+      it "encodes an event without content type" do
+        event = CloudEvents::Event.create spec_version: spec_version_v1,
+                                          id:           my_id,
+                                          source:       my_source,
+                                          type:         my_type,
+                                          data:         my_json_data
+        struct = json_format.encode_hash_structure event
+        assert_equal "application/json", struct["datacontenttype"]
+      end
+
+      it "encodes an event with nulls" do
+        struct = json_format.encode_hash_structure my_incomplete_event_v1
+        assert_equal my_incomplete_struct_v1, struct
+      end
+
+      it "encodes a minimal event" do
+        struct = json_format.encode_hash_structure my_minimal_event_v1
+        assert_equal my_minimal_struct_v1, struct
+      end
+
+      [
+        "application/json",
+        "text/json",
+        "application/json; charset=utf-8",
+        "application/blah+json",
+        "application/blah+json; foo=bar"
+      ].each do |content_type|
+        it "encodes a string data value when content type is #{content_type}" do
+          event = my_minimal_event_v1.with data: my_json_string_data, data_content_type: content_type
+          struct = json_format.encode_hash_structure event
+          assert_equal my_json_string_data, struct["data"]
+        end
+
+        it "encodes a data_encoded value when content type is #{content_type}" do
+          event = my_minimal_event_v1.with data_encoded: my_doubly_encoded_json_string_data,
+                                           data_content_type: content_type
+          struct = json_format.encode_hash_structure event
+          assert_equal my_json_string_data, struct["data"]
+        end
       end
     end
 
-    it "raises FormatSyntaxError when decoding malformed JSON event" do
-      error = assert_raises CloudEvents::FormatSyntaxError do
-        json_format.decode_event content: "!!!", content_type: structured_content_type
+    describe "decode_event" do
+      it "decodes a single event" do
+        result = json_format.decode_event content: my_json_struct_v1_string, content_type: structured_content_type
+        assert_equal my_json_event_v1, result[:event]
       end
-      assert_kind_of JSON::ParserError, error.cause
+
+      it "decodes a batch event" do
+        result = json_format.decode_event content: my_batch_v1_string, content_type: batched_content_type
+        assert_equal [my_binary_event_v1, my_json_event_v1], result[:event_batch]
+      end
+
+      it "refuses to decode non-json content types" do
+        assert_nil json_format.decode_event content: my_json_struct_v1_string, content_type: my_content_type
+      end
+
+      it "raises SpecVersionError when JSON input has a bad specversion" do
+        malformed_input = {
+          "data"            => my_json_data,
+          "datacontenttype" => my_content_type_string,
+          "id"              => my_id,
+          "source"          => my_source_string,
+          "specversion"     => "0.1",
+          "type"            => my_type
+        }
+        malformed_input_string = JSON.dump malformed_input
+        assert_raises CloudEvents::SpecVersionError do
+          json_format.decode_event content: malformed_input_string, content_type: structured_content_type
+        end
+      end
+
+      it "raises AttributeError when JSON input is missing an ID" do
+        malformed_input = {
+          "data"            => my_json_data,
+          "datacontenttype" => my_content_type_string,
+          "source"          => my_source_string,
+          "specversion"     => "1.0",
+          "type"            => my_type
+        }
+        malformed_input_string = JSON.dump malformed_input
+        assert_raises CloudEvents::AttributeError do
+          json_format.decode_event content: malformed_input_string, content_type: structured_content_type
+        end
+      end
+
+      it "raises FormatSyntaxError when decoding malformed JSON event" do
+        error = assert_raises CloudEvents::FormatSyntaxError do
+          json_format.decode_event content: "!!!", content_type: structured_content_type
+        end
+        assert_kind_of JSON::ParserError, error.cause
+      end
+
+      it "raises FormatSyntaxError when decoding malformed JSON batch" do
+        error = assert_raises CloudEvents::FormatSyntaxError do
+          json_format.decode_event content: "!!!", content_type: batched_content_type
+        end
+        assert_kind_of JSON::ParserError, error.cause
+      end
     end
 
-    it "raises FormatSyntaxError when decoding malformed JSON batch" do
-      error = assert_raises CloudEvents::FormatSyntaxError do
-        json_format.decode_event content: "!!!", content_type: batched_content_type
+    describe "encode_event" do
+      it "encodes a single event" do
+        result = json_format.encode_event event: my_json_event_v1, sort: true
+        assert_equal my_json_struct_v1_string, result[:content]
+        assert_equal structured_content_type, result[:content_type]
       end
-      assert_kind_of JSON::ParserError, error.cause
+
+      it "encodes a batch event" do
+        result = json_format.encode_event event_batch: [my_binary_event_v1, my_json_event_v1], sort: true
+        assert_equal my_batch_v1_string, result[:content]
+        assert_equal batched_content_type, result[:content_type]
+      end
+
+      it "raises UnsupportedFormatError on missing data_encoded and an unrecognized media type" do
+        event = my_string_event_v1.with data: "hello", data_content_type: "application/blah"
+        assert_raises CloudEvents::UnsupportedFormatError do
+          json_format.encode_event event: event, sort: true
+        end
+      end
     end
   end
 

--- a/test/test_text_format.rb
+++ b/test/test_text_format.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+require "base64"
+require "date"
+require "json"
+require "stringio"
+require "uri"
+
+describe CloudEvents::TextFormat do
+  let(:text_format) { CloudEvents::TextFormat.new }
+  let(:content) { '{"foo":"bar"}' }
+
+  describe "decode_data" do
+    [
+      "text/plain",
+      "text/plain; charset=utf-8",
+      "text/html",
+      "application/octet-stream"
+    ].each do |content_type|
+      it "decodes content type #{content_type}" do
+        content_type = CloudEvents::ContentType.new content_type
+        result = text_format.decode_data content: content, content_type: content_type
+        assert_equal content, result[:data]
+        assert_equal content_type, result[:content_type]
+      end
+    end
+
+    it "fails to decode content type application/json" do
+      content_type = CloudEvents::ContentType.new "application/json"
+      result = text_format.decode_data content: content, content_type: content_type
+      assert_nil result
+    end
+  end
+
+  describe "encode_data" do
+    [
+      "text/plain",
+      "text/plain; charset=utf-8",
+      "text/html",
+      "application/octet-stream"
+    ].each do |content_type|
+      it "encodes content type #{content_type}" do
+        content_type = CloudEvents::ContentType.new content_type
+        result = text_format.encode_data data: content, content_type: content_type
+        assert_equal content, result[:content]
+        assert_equal content_type, result[:content_type]
+      end
+    end
+
+    it "fails to encode content type application/json" do
+      content_type = CloudEvents::ContentType.new "application/json"
+      result = text_format.encode_data data: content, content_type: content_type
+      assert_nil result
+    end
+  end
+end


### PR DESCRIPTION
Full change list:

* Added `data_encoded`, `data_decoded?` and `data?` methods to CloudEvents::Event::V1, added `:data_encoded` as an input attribute, and clarified the encoding semantics of each field.
* Changed `:attributes` keyword argument in event constructors to `:set_attributes`, to avoid any possible collision with a real extension attribute name. (The old argument name is deprecated and will be removed in 1.0.)
* Fixed various inconsistencies in the data encoding behavior of JsonFormat and HttpBinding.
* Support passing a data content encoder/decoder into JsonFormat#encode_event and JsonFormat#decode_event.
* Provided TextFormat to handle media types with trivial encoding.
* Provided Format::Multi to handle checking a series of encoders/decoders.
