### PR TITLE
fix: Removed dependency on base64 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,11 @@
 source "https://rubygems.org"
 gemspec
 
-gem "base64", "~> 0.3"
 gem "cucumber", "~> 9.2"
 gem "google-style", "~> 1.27.1"
-gem "logger", "~> 1.7"
 gem "minitest", "~> 5.25"
 gem "minitest-focus", "~> 1.4"
 gem "minitest-rg", "~> 5.3"
-gem "ostruct", "~> 0.6"
 gem "rack", "~> 3.2"
 gem "redcarpet", "~> 3.6" unless ::RUBY_PLATFORM == "java"
 gem "webrick", "~> 1.9"

--- a/lib/cloud_events/format.rb
+++ b/lib/cloud_events/format.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "base64"
 require "json"
 
 module CloudEvents

--- a/lib/cloud_events/json_format.rb
+++ b/lib/cloud_events/json_format.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "base64"
 require "json"
 
 module CloudEvents
@@ -256,7 +255,7 @@ module CloudEvents
 
     def retrieve_content_from_data_fields structure, charset
       if structure.key? "data_base64"
-        content = ::Base64.decode64 structure.delete "data_base64"
+        content = structure.delete("data_base64").unpack1 "m"
         content_type = structure["datacontenttype"] || "application/octet-stream"
       else
         content = structure["data"]
@@ -318,7 +317,7 @@ module CloudEvents
         structure["datacontenttype"] = result[:content_type].to_s
       end
       if data_encoded.encoding == ::Encoding::ASCII_8BIT
-        structure["data_base64"] = ::Base64.encode64 data_encoded
+        structure["data_base64"] = [data_encoded].pack "m0"
         structure.delete "data"
       else
         structure["data"] = data_encoded

--- a/lib/cloud_events/text_format.rb
+++ b/lib/cloud_events/text_format.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "base64"
 require "json"
 
 module CloudEvents

--- a/test/test_json_format.rb
+++ b/test/test_json_format.rb
@@ -2,7 +2,6 @@
 
 require_relative "helper"
 
-require "base64"
 require "date"
 require "json"
 require "stringio"
@@ -19,8 +18,8 @@ describe CloudEvents::JsonFormat do
   let(:my_doubly_encoded_json_string_data) { JSON.dump my_json_string_data }
   let(:my_data_string) { "12345" }
   let(:my_json_encoded_data_string) { '"12345"' }
-  let(:my_base64_data) { "/w==\n" }
-  let(:my_binary_string) { Base64.decode64 my_base64_data }
+  let(:my_base64_data) { "/w==" }
+  let(:my_binary_string) { my_base64_data.unpack1 "m" }
   let(:my_content_encoding) { "8bit" }
   let(:my_content_type_string) { "text/plain; charset=us-ascii" }
   let(:my_content_type) { CloudEvents::ContentType.new my_content_type_string }

--- a/test/test_text_format.rb
+++ b/test/test_text_format.rb
@@ -2,7 +2,6 @@
 
 require_relative "helper"
 
-require "base64"
 require "date"
 require "json"
 require "stringio"


### PR DESCRIPTION
Replaces usage of the base64 gem with appropriate pack/unpack expressions. Removes base64, as well as a few other unnecessary standard library gems, from the Gemfile.

Note that our use of Array#pack uses the `m0` code, which eliminates newlines from the base64 encoded value. This is a behavioral change from the original code, which includes the newlines. We're making this change because the application to JSON-encoded cloudevents, while not specifying one or the other, would probably prefer to omit the newlines.

closes #82